### PR TITLE
Sane defaults and puma:check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,35 +15,41 @@ And then execute:
     $ bundle
 
 ## Usage
-
+```ruby
     # Capfile
 
-        require 'capistrano/puma'
-        require 'capistrano/puma/jungle' #if you need the jungle tasks
-
+    require 'capistrano/puma'
+    require 'capistrano/puma/jungle' #if you need the jungle tasks
+```
 
 
 Configurable options, shown here with defaults:
-
+```ruby
     set :puma_state, "#{shared_path}/tmp/pids/puma.state"
     set :puma_pid, "#{shared_path}/tmp/pids/puma.pid"
     set :puma_bind, "unix://#{shared_path}/tmp/sockets/puma.sock"
-    set :puma_conf, "#{shared_path}/config/puma.rb"
+    set :puma_conf, "#{shared_path}/puma.rb"
     set :puma_access_log, "#{shared_path}/log/puma_error.log"
     set :puma_error_log, "#{shared_path}/log/puma_access.log"
     set :puma_role, :app
     set :puma_env, fetch(:rack_env, fetch(:rails_env, 'production'))
     set :puma_threads, [0, 16]
     set :puma_workers, 0
+```
+For Jungle tasks (beta), these options exist:
+```ruby
+    set :puma_jungle_conf, '/etc/puma.conf'
+    set :puma_run_path, '/usr/local/bin/run-puma'
+```
+Ensure that the following directories are shared (via ``linked_dirs``):
 
-    For Jungle tasks (beta), these options exist:
-       set :puma_jungle_conf, '/etc/puma.conf'
-       set :puma_run_path, '/usr/local/bin/run-puma'
+    tmp/pids tmp/sockets log
 
 ## Changelog
 
-0.0.8: puma.rb is automatically generated if not present. Fixed RVM issue.
-0.0.7: Gem pushed to rubygems as capistrano3-puma. Support of Redhat based OS for Jungle init script.
+- 0.0.9: puma.rb location changed to shared_path root. puma:check moved to after deploy:check
+- 0.0.8: puma.rb is automatically generated if not present. Fixed RVM issue.
+- 0.0.7: Gem pushed to rubygems as capistrano3-puma. Support of Redhat based OS for Jungle init script.
 
 ## Contributors
 

--- a/lib/capistrano/puma/version.rb
+++ b/lib/capistrano/puma/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Puma
-    VERSION = '0.0.8'
+    VERSION = '0.0.9'
   end
 end

--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -13,7 +13,7 @@ namespace :load do
     set :puma_state, -> { File.join(shared_path, 'tmp', 'pids', 'puma.state') }
     set :puma_pid, -> { File.join(shared_path, 'tmp', 'pids', 'puma.pid') }
     set :puma_bind, -> { File.join('unix://', shared_path, 'tmp', 'sockets', 'puma.sock') }
-    set :puma_conf, -> { File.join(shared_path, 'config', 'puma.rb') }
+    set :puma_conf, -> { File.join(shared_path, 'puma.rb') }
     set :puma_access_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
 
@@ -79,7 +79,7 @@ namespace :puma do
       end
     end
   end
-  before 'deploy:check', 'puma:check'
+  after 'deploy:check', 'puma:check'
 
   def template_puma(from, to)
     erb = File.read(File.expand_path("../../templates/#{from}", __FILE__))


### PR DESCRIPTION
Sane defaults and puma:check
- Run `puma:check` after `deploy:check`, not before
- Sane Defaults: `puma.rb` config path is now `shared_path` root
- README updated with new details, added instructions for `linked_dirs`
- Version bumped

Closes #13
