### PR TITLE
bump version for support capistrano v3.1

### DIFF
--- a/capistrano-puma.gemspec
+++ b/capistrano-puma.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split($/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'capistrano', '~> 3.0.0'
+  spec.add_dependency 'capistrano', '~> 3.0'
 
 end

--- a/lib/capistrano/puma/version.rb
+++ b/lib/capistrano/puma/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Puma
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end


### PR DESCRIPTION
capistrano v3.1 is released

So capistrano3-puma should also release the new version, just for the v3.1 support
