### PR TITLE
add a trigger to puma config, for support Issue #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_env, fetch(:rack_env, fetch(:rails_env, 'production'))
     set :puma_threads, [0, 16]
     set :puma_workers, 0
-    set :puma_active_record_establish_connection, false
+    set :puma_init_active_record, false
 ```
 For Jungle tasks (beta), these options exist:
 ```ruby
@@ -52,6 +52,8 @@ Ensure that the following directories are shared (via ``linked_dirs``):
 
 ## Changelog
 
+- 0.2.0: Support for puma `ActiveRecord::Base.establish_connection` on
+  boot
 - 0.1.3: Capistrano 3.1 support
 - 0.1.2: Gemfile are refreshed between deploys now
 - 0.1.1: Initial support for Monit and configuration override added.

--- a/lib/capistrano/puma/version.rb
+++ b/lib/capistrano/puma/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Puma
-    VERSION = '0.1.4.pre'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -12,7 +12,7 @@ namespace :load do
     set :puma_conf, -> { File.join(shared_path, 'puma.rb') }
     set :puma_access_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
-    set :puma_active_record_establish_connection, false
+    set :puma_init_active_record, false
 
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w{ puma pumactl })

--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -17,7 +17,7 @@ on_restart do
   ENV["BUNDLE_GEMFILE"] = "<%= fetch(:bundle_gemfile, "#{current_path}/Gemfile") %>"
 end
 
-<% if fetch(:puma_active_record_establish_connection) %>
+<% if fetch(:puma_init_active_record) %>
 on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.establish_connection


### PR DESCRIPTION
- Remain the same config output for minor changes
- `set :puma_active_record_establish_connection, true` to enable this
  feature
