### PR TITLE
check for linked_dirs var and raise with meaningful error msg

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -14,6 +14,7 @@ namespace :load do
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
     set :puma_init_active_record, false
     set :puma_preload_app, true
+    set :puma_linked_dirs, %w{tmp/pids tmp/sockets log}
 
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w{ puma pumactl })
@@ -29,17 +30,6 @@ namespace :puma do
       template_puma 'puma', fetch(:puma_conf), role
     end
   end
-
-  desc 'check for linked_dirs config'
-  task :config_test do
-    class Array
-      def contains? other; (self & other).sort == other.sort end
-    end
-    unless fetch(:linked_dirs, []).contains? %w{tmp/pids tmp/sockets log}
-      raise RuntimeError, 'Please add %w{tmp/pids tmp/sockets log} to your `linked_dirs` setting'
-    end
-  end
-  before 'deploy:finished', 'puma:config_test'
 
   desc 'Start puma'
   task :start do
@@ -87,6 +77,13 @@ namespace :puma do
 
 
   task :check do
+    # linked_dirs config check
+    require 'set'
+    unless fetch(:linked_dirs, []).to_set.superset? fetch(:puma_linked_dirs).to_set
+      raise RuntimeError, 'Please add %w{tmp/pids tmp/sockets log} to your `linked_dirs` setting'
+    end
+
+    # check and generate puma config file
     on roles (fetch(:puma_role)) do |role|
       #Create puma.rb for new deployments
       unless  test "[ -f #{fetch(:puma_conf)} ]"


### PR DESCRIPTION
check for :linked_dirs config before start puma. but I'm not sure raise an exception is the right way to do it.

it is inspired by issue #30
