### PR TITLE
check redhat-release first

### DIFF
--- a/lib/capistrano/tasks/jungle.cap
+++ b/lib/capistrano/tasks/jungle.cap
@@ -16,12 +16,12 @@ namespace :puma do
         template_puma 'run-puma', "#{fetch(:tmp_dir)}/run-puma", role
         execute "chmod +x #{fetch(:tmp_dir)}/run-puma"
         sudo "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
-        if test '[ -f /etc/lsb-release ]'
-          #Debian flavor OS
-          debian_install
-        elsif test '[ -f /etc/redhat-release ]'
+        if test '[ -f /etc/redhat-release ]'
           #RHEL flavor OS
           rhel_install
+        elsif test '[ -f /etc/lsb-release ]'
+          #Debian flavor OS
+          debian_install
         else
           #Some other OS
           error 'This task is not supported for your OS'


### PR DESCRIPTION
1) Check for redhat-release must be done first because puma's initscript is lsb-compliant. To run such scripts we need redhat-lsb-core package installed which provides /etc/lsb-release too.
2) /etc/lsb-release existence is not a good way to check for debian anyway.
