### PR TITLE
puma jungle start stop restart fix

### DIFF
--- a/lib/capistrano/tasks/jungle.cap
+++ b/lib/capistrano/tasks/jungle.cap
@@ -72,7 +72,7 @@ namespace :puma do
       desc "#{command} puma"
       task command do
         on roles(fetch(:puma_role)) do
-          sudo "service puma #{command} #{current_path}"
+          sudo "service puma #{command} app=#{current_path}"
         end
       end
     end


### PR DESCRIPTION
Hello,

When using puma jungle commands such as start stop and restart `"sudo service puma #{command} #{current_path}"` fails and it returns 
`stop: Env must be KEY=VALUE pairs` error because `app=` key is missing.

So just this little fix.

Thanks for the gem, I find it really useful.

Cheers !
