### PR TITLE
Support Ruby 1.9.3 nor newer

### DIFF
--- a/capistrano-puma.gemspec
+++ b/capistrano-puma.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/seuros/capistrano-puma'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = '~> 1.9.3'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.files = `git ls-files`.split($/)
   spec.require_paths = ['lib']

--- a/capistrano3-puma.gemspec
+++ b/capistrano3-puma.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/seuros/capistrano-puma'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = '~> 1.9.3'
+  spec.required_ruby_version = '>= 1.9.3'
 
   spec.files = `git ls-files`.split($/)
   spec.require_paths = ['lib']


### PR DESCRIPTION
Hey @seuros,

one of your last commits specified the ruby version for this gem to be exactly _1.9.3_, but maybe you wanted to support _1.9.3 or newer_ instead?

If that's the case, here's the correct gemspec for you.

Cheers and thanks for the gem.

Philipp
