### PR TITLE
Make monit play well with chruby.

### DIFF
--- a/lib/capistrano/templates/puma_monit.conf.erb
+++ b/lib/capistrano/templates/puma_monit.conf.erb
@@ -2,9 +2,6 @@
 # Service name: <%= puma_monit_service_name %>
 #
 check process <%= puma_monit_service_name %>
- with pidfile "<%= fetch(:puma_pid) %>"
- start program = "/bin/su <%= @role.user %> -c 'source $HOME/.bashrc && cd <%= current_path %> && bundle exec puma -C <%= fetch(:puma_conf) %>'"
- stop program = "/bin/su <%= @role.user %> -c 'source $HOME/.bashrc && cd <%= current_path %> && bundle exec pumactl -S <%= fetch(:puma_state) %> stop'"
-
-
-
+  with pidfile "<%= fetch(:puma_pid) %>"
+  start program = "/usr/bin/sudo -u <%= @role.user %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec puma -C <%= fetch(:puma_conf) %>'"
+  stop program = "/usr/bin/sudo -u <%= @role.user %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec pumactl -S <%= fetch(:puma_state) %> stop'"


### PR DESCRIPTION
In my case, with https://github.com/capistrano/chruby

It will generate:

``` conf
check process puma_monit_QAirServer
  with pidfile "/var/www/QAirServer/shared/tmp/pids/puma.pid"
  start program = "/usr/bin/sudo -u vagrant /bin/bash -c 'cd /var/www/QAirServer/current && /usr/local/bin/chruby-exec 2.1.1 -- bundle exec puma -C /var/www/QAirServer/shared/puma.rb'"
  stop program = "/usr/bin/sudo -u vagrant /bin/bash -c 'cd /var/www/QAirServer/current && /usr/local/bin/chruby-exec 2.1.1 -- bundle exec pumactl -S /var/www/QAirServer/shared/tmp/pids/puma.state stop'"
```

Not yet test on RVM/rbenv, but it should work by using `SSHKit.config.command_map[:bundle]`

The `/bin/su` will ask for the password, the script will fail.

By setting `NOPASSWD` in `/etc/sudoers` file. `/usr/bin/sudo` will run as expected.
