### PR TITLE
Fix jungle tasks

### DIFF
--- a/lib/capistrano/tasks/jungle.cap
+++ b/lib/capistrano/tasks/jungle.cap
@@ -72,7 +72,7 @@ namespace :puma do
       desc "#{command} puma"
       task command do
         on roles(fetch(:puma_role)) do
-          sudo "service puma #{command} app=#{current_path}"
+          sudo "service puma #{command} #{current_path}"
         end
       end
     end


### PR DESCRIPTION
Jungle scripts are expecting second argument to perform a search in config.
