### PR TITLE
puma.rb path is not matching that in run_puma.rb

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -10,7 +10,7 @@ namespace :load do
     set :puma_state, -> { File.join(shared_path, 'tmp', 'pids', 'puma.state') }
     set :puma_pid, -> { File.join(shared_path, 'tmp', 'pids', 'puma.pid') }
     set :puma_bind, -> { File.join('unix://', shared_path, 'tmp', 'sockets', 'puma.sock') }
-    set :puma_conf, -> { File.join(shared_path, 'puma.rb') }
+    set :puma_conf, -> { File.join(shared_path, 'config', 'puma.rb') }
     set :puma_access_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
     set :puma_init_active_record, false


### PR DESCRIPTION
`run_puma.rb` expects puma.rb in the path `$APP_ROOT/shared/config/puma.rb`.
The value of `puma_config` is matching that by default.
