### PR TITLE
Cannot call nginx:config cap task

### DIFF
--- a/lib/capistrano/tasks/nginx.cap
+++ b/lib/capistrano/tasks/nginx.cap
@@ -1,8 +1,8 @@
 namespace :nginx do
   desc "Setup nginx configuration"
   task :config do
-    on roles(:puma_nginx) do
-      template_puma("nginx_conf", "/tmp/nginx_#{fetch(:nginx_config_name)}")
+    on roles(:puma_nginx) do |role|
+      template_puma("nginx_conf", "/tmp/nginx_#{fetch(:nginx_config_name)}", role)
       sudo :mv, "/tmp/nginx_#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)}"
       sudo :ln, '-fs', "#{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_enabled_path)}/#{fetch(:nginx_config_name)}"
     end


### PR DESCRIPTION
template_puma is called with 2 arguments instead of 3
