### PR TITLE
Fixed handling of multiple puma endpoints and of wildcard IP addresses

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -27,7 +27,9 @@ namespace :load do
     set :nginx_sites_available_path, -> { '/etc/nginx/sites-available' }
     set :nginx_sites_enabled_path, -> { '/etc/nginx/sites-enabled' }
     set :nginx_server_name, -> { "localhost #{fetch(:application)}.local" }
-
+    set :nginx_flags, -> { 'fail_timeout=0' }
+		set :nginx_http_flags, -> { fetch(:nginx_flags) }
+		set :nginx_socket_flags -> { fetch(:nginx_flags) }
   end
 end
 

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -1,5 +1,15 @@
-upstream puma_<%= fetch(:nginx_config_name) %> {
-  server <%= fetch(:puma_bind) %> fail_timeout=0;
+upstream puma_<%= fetch(:nginx_config_name) %> { <%
+  flags = 'fail_timeout=0'
+  @backends = [fetch(:puma_bind)].flatten.map do |m|
+  etype, address  = /(tcp|unix|ssl):\/\/(.+)/.match(m).captures
+  if etype =='unix'
+    "server #{etype}:#{address} #{fetch(:nginx_socket_flags)};"
+  else
+    "server #{address.gsub(/0\.0\.0\.0(.+)/, "127.0.0.1\\1")} #{fetch(:nginx_http_flags)};"
+  end
+end
+%><% @backends.each do |server|  %>
+  <%= server %><% end %>
 }
 
 server {


### PR DESCRIPTION
Improved the handling of multiple upstream endpoints and of app servers configured to use "0.0.0.0" as IP address.
