### PR TITLE
Fix puma_bind unix socket path

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -11,7 +11,7 @@ namespace :load do
     set :puma_rackup, -> { File.join(current_path, 'config.ru') }
     set :puma_state, -> { File.join(shared_path, 'tmp', 'pids', 'puma.state') }
     set :puma_pid, -> { File.join(shared_path, 'tmp', 'pids', 'puma.pid') }
-    set :puma_bind, -> { File.join('unix://', shared_path, 'tmp', 'sockets', 'puma.sock') }
+    set :puma_bind, -> { File.join("unix://#{shared_path}", 'tmp', 'sockets', 'puma.sock') }
     set :puma_conf, -> { File.join(shared_path, 'puma.rb') }
     set :puma_access_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_error.log') }


### PR DESCRIPTION
I don't know what was the decision behind setting all paths with `File.join` instead of an interpolated string, and if it is worth rolling back (so I didn't), but `File.join` seems to mess up the unix socket URL:

```
> File.join('unix://', '/home/deploy/app', 'tmp', 'sockets', 'puma.socket') # => "unix:/home/deploy/app/tmp/sockets/puma.socket"
> File.join('unix://home/deploy/app', 'tmp', 'sockets', 'puma.socket') # => "unix://home/deploy/app/tmp/sockets/puma.socket"
```
