### PR TITLE
Start task creates a conf file if none exists.

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -1,3 +1,4 @@
+
 namespace :load do
   task :defaults do
     set :puma_default_hooks, -> { true }
@@ -51,6 +52,11 @@ namespace :puma do
   desc 'Start puma'
   task :start do
     on roles (fetch(:puma_role)) do
+      if test "[ -f #{fetch(:puma_conf)} ]"
+        info "using conf file #{fetch(:puma_conf)}"
+      else
+        invoke 'puma:config'
+      end
       within current_path do
         with rack_env: fetch(:puma_env) do
 
@@ -94,7 +100,7 @@ namespace :puma do
               execute :bundle, 'exec', :pumactl, "-S #{fetch(:puma_state)} #{command}"
             else
               # Puma is not running or state file is not present : Run it
-              execute :bundle, 'exec', :puma, "-C #{fetch(:puma_conf)} --daemon"
+              invoke 'puma:start'
             end
           end
         end


### PR DESCRIPTION
Restart invokes start task if not started instead of duplicating its content.
