### PR TITLE
Allow unix:/foo/ socket URLs

### DIFF
--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -1,7 +1,7 @@
 upstream puma_<%= fetch(:nginx_config_name) %> { <%
   flags = 'fail_timeout=0'
   @backends = [fetch(:puma_bind)].flatten.map do |m|
-  etype, address  = /(tcp|unix|ssl):\/\/(.+)/.match(m).captures
+  etype, address  = /(tcp|unix|ssl):\/{1,2}(.+)/.match(m).captures
   if etype =='unix'
     "server #{etype}:#{address} #{fetch(:nginx_socket_flags)};"
   else


### PR DESCRIPTION
The current regex requires unix://, which doesn't really make sense for unix sockets. A single forward slash is all that's required, and all that Puma and Nginx expect. In fact, it's even the default value for `fetch(:puma_bind)`.