### PR TITLE
Fix smart_restart task to check if puma preloads app

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -122,7 +122,7 @@ namespace :puma do
 
 
   task :smart_restart do
-    if  puma_workers.to_i > 1
+    if !puma_preload_app? && puma_workers.to_i > 1
       invoke 'puma:phased-restart'
     else
       invoke 'puma:restart'
@@ -135,6 +135,9 @@ namespace :puma do
     fetch(:puma_workers, 0)
   end
 
+  def puma_preload_app?
+    fetch(:puma_preload_app)
+  end
 
   def puma_bind
     Array(fetch(:puma_bind)).collect do |bind|


### PR DESCRIPTION
I was faced with a conflict between phased restart and puma's preload_app.

```ruby
set :puma_threads, [4, 4]
set :puma_workers, 2
set :puma_preload_app, true
```

With this config gem invokes `phased-restart`, which is not recommended for preload_app.

My changes makes gem not to rely only on `puma_workers`, but also on `puma_preload_app`, to decide what restart method  to be invoked.