### PR TITLE
bundler prune should be automatically detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_worker_timeout, nil
     set :puma_init_active_record, false
     set :puma_preload_app, true
-    set :puma_prune_bundler, false
 ```
 For Jungle tasks (beta), these options exist:
 ```ruby

--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -17,7 +17,6 @@ namespace :load do
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_init_active_record, false
     set :puma_preload_app, true
-    set :puma_prune_bundler, false
 
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w{ puma pumactl })

--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -21,10 +21,15 @@ worker_timeout <%= fetch(:puma_worker_timeout).to_i %>
 
 <% if fetch(:puma_preload_app) %>
 preload_app!
+
+on_restart do
+  puts 'Refreshing Gemfile'
+  ENV["BUNDLE_GEMFILE"] = "<%= fetch(:bundle_gemfile, "#{current_path}/Gemfile") %>"
+end
 <% end %>
 
-<% if fetch(:puma_prune_bundler) %>
-prune_bundler
+<% if ! fetch(:puma_preload_app) %>
+prune_bundle
 <% end %>
 
 <% if fetch(:puma_init_active_record) %>


### PR DESCRIPTION
## New behavier of puma_prune_bundler make my deployment crash again

In the case puma __preload_app!__ is incompatible with __puma_prune_bundler__ [https://github.com/puma/puma/blob/master/examples/config.rb#L132]()

and puma will crash because of bundle context not switch between each capistrano deployment (even with the `puma:restart`, which is using by default with __preload_app__)

> /opt/ruby21/share/gems/gems/bundler-1.8.3/lib/bundler/definition.rb:22:in `build': /path/to/Gemfile/with/deleted/capistrano/deleted/path/20150303095846/Gemfile not found (Bundler::GemfileNotFound)

## So here is my point
To make sure bundler is automatically switched between each deploy and do the right thing for __preload_app__ or not.

@behe any idea?