### PR TITLE
Set :puma_preload_app to false

### DIFF
--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -17,7 +17,7 @@ namespace :load do
     set :puma_access_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_init_active_record, false
-    set :puma_preload_app, true
+    set :puma_preload_app, false
 
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w{ puma pumactl })


### PR DESCRIPTION
Since the default number of workers is zero, preload_app default config should be false

After reading the [puma's README](https://github.com/puma/puma/blob/master/README.md), I noticed they don't recommend to use *preload_app* if you're not using workers. I think it'd better to set the default to false.

> General rule is to use preload_app when your workers die often and need fast starts. If you don’t have many workers, you probably should not use preload_app