### PR TITLE
fix the issue that `sudo` tasks hang on password input.

### DIFF
--- a/lib/capistrano/tasks/jungle.cap
+++ b/lib/capistrano/tasks/jungle.cap
@@ -15,7 +15,7 @@ namespace :puma do
         @role = role
         template_puma 'run-puma', "#{fetch(:tmp_dir)}/run-puma", role
         execute "chmod +x #{fetch(:tmp_dir)}/run-puma"
-        sudo "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
+        sudo_command "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
         if test '[ -f /etc/redhat-release ]'
           #RHEL flavor OS
           rhel_install
@@ -26,7 +26,7 @@ namespace :puma do
           #Some other OS
           error 'This task is not supported for your OS'
         end
-        sudo "touch #{fetch(:puma_jungle_conf)}"
+        sudo_command "touch #{fetch(:puma_jungle_conf)}"
       end
     end
 
@@ -34,16 +34,16 @@ namespace :puma do
     def debian_install
       template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", @role
       execute "chmod +x #{fetch(:tmp_dir)}/puma"
-      sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
-      sudo 'update-rc.d -f puma defaults'
+      sudo_command "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
+      sudo_command 'update-rc.d -f puma defaults'
 
     end
 
     def rhel_install
       template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma" , @role
       execute "chmod +x #{fetch(:tmp_dir)}/puma"
-      sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
-      sudo 'chkconfig --add puma'
+      sudo_command "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
+      sudo_command 'chkconfig --add puma'
     end
 
 
@@ -57,14 +57,14 @@ namespace :puma do
     desc 'Add current project to the jungle'
     task :add do
       on roles(fetch(:puma_role)) do|role|
-        sudo "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)}"
+        sudo_command "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)}"
       end
     end
 
     desc 'Remove current project from the jungle'
     task :remove do
       on roles(fetch(:puma_role)) do
-        sudo "/etc/init.d/puma remove '#{current_path}'"
+        sudo_command "/etc/init.d/puma remove '#{current_path}'"
       end
     end
 
@@ -72,7 +72,7 @@ namespace :puma do
       desc "#{command} puma"
       task command do
         on roles(fetch(:puma_role)) do
-          sudo "service puma #{command} #{current_path}"
+          sudo_command "service puma #{command} #{current_path}"
         end
       end
     end

--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -13,42 +13,42 @@ namespace :puma do
       on roles(fetch(:puma_role)) do |role|
         @role = role
         template_puma 'puma_monit.conf', "#{fetch(:tmp_dir)}/monit.conf", @role
-        sudo "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:puma_monit_conf_dir)}"
+        sudo_command "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:puma_monit_conf_dir)}"
       end
     end
 
     desc 'Monitor Puma monit-service'
     task :monitor do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_monit_bin)} monitor #{puma_monit_service_name}"
+        sudo_command "#{fetch(:puma_monit_bin)} monitor #{puma_monit_service_name}"
       end
     end
 
     desc 'Unmonitor Puma monit-service'
     task :unmonitor do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_monit_bin)}  unmonitor #{puma_monit_service_name}"
+        sudo_command "#{fetch(:puma_monit_bin)}  unmonitor #{puma_monit_service_name}"
       end
     end
 
     desc 'Start Puma monit-service'
     task :start do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_monit_bin)}  start #{puma_monit_service_name}"
+        sudo_command "#{fetch(:puma_monit_bin)}  start #{puma_monit_service_name}"
       end
     end
 
     desc 'Stop Puma monit-service'
     task :stop do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_monit_bin)}  stop #{puma_monit_service_name}"
+        sudo_command "#{fetch(:puma_monit_bin)}  stop #{puma_monit_service_name}"
       end
     end
 
     desc 'Restart Puma monit-service'
     task :restart do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_monit_bin)}  restart #{puma_monit_service_name}"
+        sudo_command "#{fetch(:puma_monit_bin)}  restart #{puma_monit_service_name}"
       end
     end
 

--- a/lib/capistrano/tasks/nginx.cap
+++ b/lib/capistrano/tasks/nginx.cap
@@ -3,8 +3,8 @@ namespace :puma do
   task :nginx_config do
     on roles(fetch(:puma_nginx, :web)) do |role|
       template_puma("nginx_conf", "/tmp/nginx_#{fetch(:nginx_config_name)}", role)
-      sudo :mv, "/tmp/nginx_#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)}"
-      sudo :ln, '-fs', "#{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_enabled_path)}/#{fetch(:nginx_config_name)}"
+      sudo_command "mv /tmp/nginx_#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)}"
+      sudo_command "ln -fs #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_enabled_path)}/#{fetch(:nginx_config_name)}"
     end
   end
 end

--- a/lib/capistrano/tasks/puma.cap
+++ b/lib/capistrano/tasks/puma.cap
@@ -167,6 +167,11 @@ namespace :puma do
     end
   end
 
+  def sudo_command(str)
+    ask(:password, "pwd", echo: false)
+    execute "echo #{fetch(:password)} | sudo -S  " + str
+  end
+
   task :add_default_hooks do
     after 'deploy:check', 'puma:check'
     after 'deploy:finished', 'puma:smart_restart'


### PR DESCRIPTION
The sudo related tasks hang on the password input. It may be due to the deprecation of `sudo`  in Capistrano 3. So I walkaround the issue by utilizing the `ask` method.
