### PR TITLE
Reload Monit after uploading any monit configuration

### DIFF
--- a/lib/capistrano/tasks/monit.cap
+++ b/lib/capistrano/tasks/monit.cap
@@ -14,6 +14,7 @@ namespace :puma do
         @role = role
         template_puma 'puma_monit.conf', "#{fetch(:tmp_dir)}/monit.conf", @role
         sudo "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:puma_monit_conf_dir)}"
+        sudo "#{fetch(:puma_monit_bin)} reload"
       end
     end
 


### PR DESCRIPTION
Not reloading monit will cause monit to complain with the error `monit: action failed -- There is no service by that name`