### PR TITLE
Don't need establish connection block if `puma_preload_app' set to false

### DIFF
--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -33,7 +33,7 @@ on_restart do
   ENV["BUNDLE_GEMFILE"] = "<%= fetch(:bundle_gemfile, "#{current_path}/Gemfile") %>"
 end
 
-<% if fetch(:puma_init_active_record) %>
+<% if puma_preload_app? and fetch(:puma_init_active_record) %>
 on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.establish_connection


### PR DESCRIPTION
According to https://github.com/puma/puma/issues/728. As @evanphx said, there is no need of `on_worker_boot ` block when using `prune_bundler`.