### PR TITLE
Use SSHKit command_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Ensure that the following directories are shared (via ``linked_dirs``):
 - [fang duan](https://github.com/dfang)
 - [Steve Madere](https://github.com/stevemadere)
 - [Matias De Santi](https://github.com/mdesanti)
+- [Huang Bin](https://github.com/hbin)
 
 ## Contributing
 

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -1,4 +1,3 @@
-
 namespace :load do
   task :defaults do
     set :puma_default_hooks, -> { true }
@@ -22,6 +21,9 @@ namespace :load do
     # Rbenv and RVM integration
     set :rbenv_map_bins, fetch(:rbenv_map_bins).to_a.concat(%w{ puma pumactl })
     set :rvm_map_bins, fetch(:rvm_map_bins).to_a.concat(%w{ puma pumactl })
+
+    # Bundler integration
+    set :bundle_bins, fetch(:bundle_bins).to_a.concat(%w{ puma pumactl })
 
     # Nginx and puma configuration
     set :nginx_config_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
@@ -61,7 +63,7 @@ namespace :puma do
         end
         within current_path do
           with rack_env: fetch(:puma_env) do
-            execute :bundle, 'exec', :puma, "-C #{fetch(:puma_conf)} --daemon"
+            execute :puma, "-C #{fetch(:puma_conf)} --daemon"
           end
         end
       end
@@ -77,7 +79,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]"
                 if test "kill -0 $( cat #{fetch(:puma_pid)} )"
-                  execute :bundle, 'exec', :pumactl, "-S #{fetch(:puma_state)} #{command}"
+                  execute :pumactl, "-S #{fetch(:puma_state)} #{command}"
                 else
                   # delete invalid pid file , process is not running.
                   execute :rm, fetch(:puma_pid)
@@ -102,7 +104,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]" and test "kill -0 $( cat #{fetch(:puma_pid)} )"
                 # NOTE pid exist but state file is nonsense, so ignore that case
-                execute :bundle, 'exec', :pumactl, "-S #{fetch(:puma_state)} #{command}"
+                execute :pumactl, "-S #{fetch(:puma_state)} #{command}"
               else
                 # Puma is not running or state file is not present : Run it
                 invoke 'puma:start'

--- a/lib/capistrano/templates/puma_monit.conf.erb
+++ b/lib/capistrano/templates/puma_monit.conf.erb
@@ -3,5 +3,5 @@
 #
 check process <%= puma_monit_service_name %>
   with pidfile "<%= fetch(:puma_pid) %>"
-  start program = "/usr/bin/sudo -u <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec puma -C <%= fetch(:puma_conf) %> --daemon'"
-  stop program = "/usr/bin/sudo -u <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:bundle] %> exec pumactl -S <%= fetch(:puma_state) %> stop'"
+  start program = "/usr/bin/sudo -u <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
+  stop program = "/usr/bin/sudo -u <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"


### PR DESCRIPTION
Same as https://github.com/seuros/capistrano-sidekiq/pull/104

We don't need to explicitly specify the bundle exec statement(actually, we shouldn't).

The best practice is add the binaries to the bundle_bins array.

With following the best practice, the user can easily to custom the execution command, for example, I am going to use the dotenv executable to launch the puma. I can add an additive task like this:

```
namespace :bundler do
  task :map_bins do
    fetch(:bundle_bins).each do |command|
      SSHKit.config.command_map.prefix[command.to_sym].push('dotenv')
    end
  end
end
```