### PR TITLE
Issue #120 -- explicitly pass the config file location to pumactl

### DIFF
--- a/lib/capistrano/puma/version.rb
+++ b/lib/capistrano/puma/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Puma
-    VERSION = '1.2.1'
+    VERSION = '1.2.2'
   end
 end

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -79,7 +79,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]"
                 if test "kill -0 $( cat #{fetch(:puma_pid)} )"
-                  execute :pumactl, "-S #{fetch(:puma_state)} #{command}"
+                  execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
                 else
                   # delete invalid pid file , process is not running.
                   execute :rm, fetch(:puma_pid)
@@ -104,7 +104,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]" and test "kill -0 $( cat #{fetch(:puma_pid)} )"
                 # NOTE pid exist but state file is nonsense, so ignore that case
-                execute :pumactl, "-S #{fetch(:puma_state)} #{command}"
+                execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
               else
                 # Puma is not running or state file is not present : Run it
                 invoke 'puma:start'


### PR DESCRIPTION
To override this change in puma 2.12.0 
" * Make pumactl load config/puma.rb by default"

which causes issue #120 