### PR TITLE
Add basic authentication option for nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ or define a standalone one:
 role :puma_nginx, %w{root@example.com}
 ```
 
+if you want to use Basic Authentication on your server you can set the following
+```
+set :nginx_use_basicauth, true
+set :nginx_basicauth_location, "/var/www/_htpasswd/<your_project_name>.htpasswd"
+```
+
 Configurable options, shown here with defaults: Please note the configuration options below are not required unless you are trying to override a default setting, for instance if you are deploying on a host on which you do not have sudo or root privileges and you need to restrict the path. These settings go in the deploy.rb file.
 
 ```ruby
@@ -70,6 +76,8 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_worker_timeout, nil
     set :puma_init_active_record, false
     set :puma_preload_app, true
+    set :nginx_use_basicauth, false
+    set :nginx_basicauth_location, "/var/www/_htpasswd/#{project_name}.htpasswd"
     set :nginx_use_ssl, false
 ```
 For Jungle tasks (beta), these options exist:

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -53,7 +53,7 @@ server {
 <% if fetch(:nginx_use_basicauth) && fetch(:nginx_basicauth_location) %>
     # Basic authentication
     auth_basic "Restricted";
-    auth_basic_user_file <%= fetch(:nginx_basicauth_location) %>;
+    auth_basic_user_file <%= "#{fetch(:nginx_basicauth_location)}" %>;
 <% end %>
   }
 

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -49,6 +49,12 @@ server {
     # limit_req zone=one;
     access_log <%= shared_path %>/log/nginx.access.log;
     error_log <%= shared_path %>/log/nginx.error.log;
+
+<% if fetch(:nginx_use_basicauth) && fetch(:nginx_basicauth_location) %>
+    # Basic authentication
+    auth_basic "Restricted";
+    auth_basic_user_file <%= fetch(:nginx_basicauth_location) %>;
+<% end %>
   }
 
   location ^~ /assets/ {


### PR DESCRIPTION
Basically this puts the following lines in your nginx config if you want. I have to do it manually now for our test and staging environments and i would like it to be automatic.

```
auth_basic "Restricted";
auth_basic_user_file /var/www/_htpasswd/<propject_name>.htpasswd;
```

I couldn't find where the defaults are defined, if someone can tell me i add the default configs for this. 
