### PR TITLE
Respect the global puma_user setting

### DIFF
--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -79,7 +79,7 @@ namespace :puma do
           puma_switch_user(role) do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]"
-                if test "kill -0 $( cat #{fetch(:puma_pid)} )"
+                if test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
                   execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
                 else
                   # delete invalid pid file , process is not running.
@@ -103,7 +103,7 @@ namespace :puma do
         within current_path do
           puma_switch_user(role) do
             with rack_env: fetch(:puma_env) do
-              if test "[ -f #{fetch(:puma_pid)} ]" and test "kill -0 $( cat #{fetch(:puma_pid)} )"
+              if test "[ -f #{fetch(:puma_pid)} ]" and test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
                 # NOTE pid exist but state file is nonsense, so ignore that case
                 execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
               else

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -152,6 +152,7 @@ namespace :puma do
   def puma_user(role)
     properties = role.properties
     properties.fetch(:puma_user) ||               # local property for puma only
+    fetch(:puma_user) ||
     properties.fetch(:run_as) || # global property across multiple capistrano gems
     role.user
   end

--- a/lib/capistrano/tasks/workers.rake
+++ b/lib/capistrano/tasks/workers.rake
@@ -21,7 +21,7 @@ namespace :puma do
     task :more do
       on roles (fetch(:puma_role)) do |role|
         puma_switch_user(role) do
-          execute("kill -TTIN `cat  #{fetch(:puma_pid)}`")
+          execute(:kill, "-TTIN `cat  #{fetch(:puma_pid)}`")
         end
       end
     end
@@ -30,7 +30,7 @@ namespace :puma do
     task :less do
       on roles (fetch(:puma_role)) do |role|
         puma_switch_user(role) do
-          execute("kill -TTOU `cat  #{fetch(:puma_pid)}`")
+          execute(:kill, "-TTOU `cat  #{fetch(:puma_pid)}`")
         end
       end
     end


### PR DESCRIPTION
The README mentions `set :puma_user, 'myuser'`, but the setting is ignored. It only works as a per-role setting: `role :app, %w(puma1 puma1), puma_user: 'myuser'`. This PR allows both to work, giving giving higher priority to the per-role setting.