### PR TITLE
Fix README: default value of puma_preload_app is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_workers, 0
     set :puma_worker_timeout, nil
     set :puma_init_active_record, false
-    set :puma_preload_app, true
+    set :puma_preload_app, false
     set :nginx_use_ssl, false
 ```
 For Jungle tasks (beta), these options exist:


### PR DESCRIPTION
Default value of puma_preload_app was changed false via 013bb17ce0c79bfd3e40bf9648ddb819d9f6e58b

https://github.com/seuros/capistrano-puma/blob/master/lib/capistrano/tasks/puma.rake#L19