### PR TITLE
Add server_name to the http->https redirection server block

### DIFF
--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -14,6 +14,7 @@ end
 <% if fetch(:nginx_use_ssl) %>
 server {
   listen 80;
+  server_name <%= fetch(:nginx_server_name) %>;
   rewrite ^(.*) https://$host$1 permanent;
 }
 <% end %>


### PR DESCRIPTION
Without this change `nginx -t` warns about `conflicting server name "" on 0.0.0.0:80` when running multiple SSL enabled apps. Visiting a configured domain via HTTP results in a 502 Bad Gateway error.