### PR TITLE
Fixed commands for puma start/stop/restart

### DIFF
--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -64,7 +64,7 @@ namespace :puma do
         end
         within current_path do
           with rack_env: fetch(:puma_env) do
-            execute :puma, "-C #{fetch(:puma_conf)} --daemon"
+            execute :bundle, 'exec', :puma, "-C #{fetch(:puma_conf)} --daemon"
           end
         end
       end
@@ -80,7 +80,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]"
                 if test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
-                  execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
+                  execute :bundle, 'exec', :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
                 else
                   # delete invalid pid file , process is not running.
                   execute :rm, fetch(:puma_pid)
@@ -105,7 +105,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]" and test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
                 # NOTE pid exist but state file is nonsense, so ignore that case
-                execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
+                execute :bundle, 'exec', :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
               else
                 # Puma is not running or state file is not present : Run it
                 invoke 'puma:start'


### PR DESCRIPTION
I believe issue #149 is a regression introduced in PR #128. After reverting the changes, the following commands would run successfully:
```
bundle exec cap staging puma:start
bundle exec cap staging puma:stop
bundle exec cap staging puma:restart
```