### PR TITLE
Fix sudo use

### DIFF
--- a/lib/capistrano/templates/puma_monit.conf.erb
+++ b/lib/capistrano/templates/puma_monit.conf.erb
@@ -3,5 +3,5 @@
 #
 check process <%= puma_monit_service_name %>
   with pidfile "<%= fetch(:puma_pid) %>"
-  start program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
-  stop program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"
+  start program = "/bin/su - <%= puma_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
+  stop program = "/bin/su - <%= puma_user(@role) %> -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"


### PR DESCRIPTION
I found an issue when I used the monit integration of this gem with the following settings.

```
set :rbenv_type, :system
set :rbenv_ruby, '2.3.0'
set :rbenv_path, '/usr/local/src/rbenv'
```

It can't find Ruby `2.3.0` of the rbenv correctly and failed. I think it is because appropriate envs are not set in the context and we don't have to execute `bash` through `sudo` actually, so it can use the context of the deploy user.
