### PR TITLE
Changing how the sudo command is issued in the monit config

### DIFF
--- a/lib/capistrano/templates/puma_monit.conf.erb
+++ b/lib/capistrano/templates/puma_monit.conf.erb
@@ -3,5 +3,5 @@
 #
 check process <%= puma_monit_service_name %>
   with pidfile "<%= fetch(:puma_pid) %>"
-  start program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
-  stop program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"
+  start program = "/usr/bin/sudo su - <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
+  stop program = "/usr/bin/sudo su - <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"


### PR DESCRIPTION
Thanks for this awesome project! Super useful.

I found that without this change, `monit` does **not** actually start up my puma server. After looking at it a little more closely I found that issuing `sudo` commands with `-iu` in Ubuntu 16.04 LTS would give an error like:

> Sorry, user deployer is not allowed to execute '/bin/bash -c cd /var/www/xyzapp/current && /usr/local/rbenv/bin/rbenv exec bundle exec puma -C /var/www/xyzapp/shared/config/puma.rb --daemon' as deployer on xenial64-with-puppet.

I tried other more vanilla commands as well, like

```bash
sudo -iu deployer /bin/bash -c uptime
```

and ran into the same problem.