### PR TITLE
Add 'daemonize' config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_worker_timeout, nil
     set :puma_init_active_record, false
     set :puma_preload_app, false
+    set :puma_daemonize, true
     set :puma_plugins, []  #accept array of plugins
     set :nginx_use_ssl, false
 ```

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -17,6 +17,7 @@ namespace :load do
     set :puma_error_log, -> { File.join(shared_path, 'log', 'puma_error.log') }
     set :puma_init_active_record, false
     set :puma_preload_app, false
+    set :puma_daemonize, false
 
     # Chruby, Rbenv and RVM integration
     append :chruby_map_bins, 'puma', 'pumactl'
@@ -153,6 +154,10 @@ namespace :puma do
 
   def puma_preload_app?
     fetch(:puma_preload_app)
+  end
+
+  def puma_daemonize?
+    fetch(:puma_daemonize)
   end
 
   def puma_bind

--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -24,6 +24,10 @@ workers <%= puma_workers %>
 worker_timeout <%= fetch(:puma_worker_timeout).to_i %>
 <% end %>
 
+<% if puma_daemonize? %>
+daemonize
+<% end %>
+
 <% if puma_preload_app? %>
 preload_app!
 <% else %>


### PR DESCRIPTION
Allows to set `set :puma_daemonize, true` config to use Puma `daemonize` instruction.

This can be useful when not using Puma's `--daemon` option or through `pumactl`.