### PR TITLE
Skip puma start command if puma is running

### DIFF
--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -52,9 +52,14 @@ namespace :puma do
         else
           invoke 'puma:config'
         end
-        within current_path do
-          with rack_env: fetch(:puma_env) do
-            execute :puma, "-C #{fetch(:puma_conf)} --daemon"
+
+        if test "[ -f #{fetch(:puma_pid)} ]" and test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
+          info 'Already Puma is running'
+        else
+          within current_path do
+            with rack_env: fetch(:puma_env) do
+              execute :puma, "-C #{fetch(:puma_conf)} --daemon"
+            end
           end
         end
       end


### PR DESCRIPTION
Now, when I try `puma:start` command for a server already running puma, cause this error.

```
`add_unix_listener': There is already a server bound to: /path/to/puma.sock (RuntimeError)
```

I fixed to skip puma start command if found puma process.

```sh
$ bundle exec cap puma:start # first
00:00 puma:start
      using conf file /path/to/puma.rb
      01 bundle exec puma -C /path/to/puma.rb --daemon
      01 * Pruning Bundler environment
      01 [13747] Puma starting in cluster mode...
      01 [13747] * Version 3.7.1 (ruby 2.4.0-p0), codename: Snowy Sagebrush
      01 [13747] * Min threads: 0, max threads: 16
      01 [13747] * Environment: staging
      01 [13747] * Process workers: 1
      01 [13747] * Phased restart available
      01 [13747] * Listening on unix:///path/to/puma.sock
      01 [13747] * Daemonizing...
    ✔ 01 dev@XXX.XXX.XXX.XXX 0.517s
$ bundle exec cap puma:start #second
00:00 puma:start
      using conf file /path/to/puma.rb
      Already Puma is running
```

Thanks.