### PR TITLE
Fix vars loading issue during plugin initialization

### DIFF
--- a/lib/capistrano/puma/nginx.rb
+++ b/lib/capistrano/puma/nginx.rb
@@ -3,10 +3,10 @@ module Capistrano
     include PumaCommon
     def set_defaults
       # Nginx and puma configuration
-      set_if_empty :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
+      set_if_empty :nginx_config_name, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
       set_if_empty :nginx_sites_available_path, '/etc/nginx/sites-available'
       set_if_empty :nginx_sites_enabled_path, '/etc/nginx/sites-enabled'
-      set_if_empty :nginx_server_name,  "localhost #{fetch(:application)}.local"
+      set_if_empty :nginx_server_name,  -> { "localhost #{fetch(:application)}.local" }
       set_if_empty :nginx_flags, 'fail_timeout=0'
       set_if_empty :nginx_http_flags, fetch(:nginx_flags)
       set_if_empty :nginx_socket_flags, fetch(:nginx_flags)


### PR DESCRIPTION
It looks like in 3.0.1 with explicit plugin loading the `:application` var is not set at the plugin loading stage.