### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_state, "#{shared_path}/tmp/pids/puma.state"
     set :puma_pid, "#{shared_path}/tmp/pids/puma.pid"
     set :puma_bind, "unix://#{shared_path}/tmp/sockets/puma.sock"    #accept array for multi-bind
+    set :puma_control_app, false
     set :puma_default_control_app, "unix://#{shared_path}/tmp/sockets/pumactl.sock"
     set :puma_conf, "#{shared_path}/puma.rb"
     set :puma_access_log, "#{shared_path}/log/puma_access.log"
@@ -115,6 +116,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_preload_app, false
     set :puma_daemonize, true
     set :puma_plugins, []  #accept array of plugins
+    set :puma_tag, fetch(:application)
     set :nginx_use_ssl, false
 ```
 

--- a/lib/capistrano/puma.rb
+++ b/lib/capistrano/puma.rb
@@ -66,6 +66,7 @@ module Capistrano
       set_if_empty :puma_state, -> { File.join(shared_path, 'tmp', 'pids', 'puma.state') }
       set_if_empty :puma_pid, -> { File.join(shared_path, 'tmp', 'pids', 'puma.pid') }
       set_if_empty :puma_bind, -> { File.join("unix://#{shared_path}", 'tmp', 'sockets', 'puma.sock') }
+      set_if_empty :puma_control_app, false
       set_if_empty :puma_default_control_app, -> { File.join("unix://#{shared_path}", 'tmp', 'sockets', 'pumactl.sock') }
       set_if_empty :puma_conf, -> { File.join(shared_path, 'puma.rb') }
       set_if_empty :puma_access_log, -> { File.join(shared_path, 'log', 'puma_access.log') }
@@ -73,6 +74,7 @@ module Capistrano
       set_if_empty :puma_init_active_record, false
       set_if_empty :puma_preload_app, false
       set_if_empty :puma_daemonize, false
+      set_if_empty :puma_tag, ''
 
       # Chruby, Rbenv and RVM integration
       append :chruby_map_bins, 'puma', 'pumactl'

--- a/lib/capistrano/puma.rb
+++ b/lib/capistrano/puma.rb
@@ -41,7 +41,7 @@ module Capistrano
           "config/deploy/templates/#{from}.rb.erb",
           "config/deploy/templates/#{from}.rb",
           "config/deploy/templates/#{from}.erb",
-          File.expand_path("../templates/#{from}.erb", __FILE__),
+          File.expand_path("../templates/#{from}.rb.erb", __FILE__),
       ].detect { |path| File.file?(path) }
       erb = File.read(file)
       backend.upload! StringIO.new(ERB.new(erb, nil, '-').result(binding)), to
@@ -107,7 +107,7 @@ module Capistrano
     end
 
     def upload_puma_rb(role)
-      template_puma 'puma.rb', fetch(:puma_conf), role
+      template_puma 'puma', fetch(:puma_conf), role
     end
   end
 end

--- a/lib/capistrano/puma/workers.rb
+++ b/lib/capistrano/puma/workers.rb
@@ -1,5 +1,7 @@
 module Capistrano
   class Puma::Workers < Capistrano::Plugin
+    include PumaCommon
+
     def define_tasks
       eval_rakefile File.expand_path('../../tasks/workers.rake', __FILE__)
     end

--- a/lib/capistrano/tasks/workers.rake
+++ b/lib/capistrano/tasks/workers.rake
@@ -9,7 +9,8 @@ namespace :puma do
           #TODO
           # cleanup
           # add host name/ip
-          workers_count = capture("ps ax | grep -c 'puma: cluster worker [0-9]: `cat  #{fetch(:puma_pid)}`'").to_i - 1
+          puma_pid = capture("cat #{fetch(:puma_pid)}")
+          workers_count = capture("ps ax | grep -c 'puma: cluster worker [0-9]: #{puma_pid}'").to_i
           log "Workers count : #{workers_count}"
         end
       end
@@ -23,7 +24,8 @@ namespace :puma do
     task :more do
       on roles(fetch(:puma_role)) do |role|
         git_plugin.puma_switch_user(role) do
-          execute(:kill, "-TTIN `cat  #{fetch(:puma_pid)}`")
+          puma_pid = capture("cat  #{fetch(:puma_pid)}")
+          execute(:kill, "-TTIN #{puma_pid}")
         end
       end
     end
@@ -32,7 +34,8 @@ namespace :puma do
     task :less do
       on roles(fetch(:puma_role)) do |role|
         git_plugin.puma_switch_user(role) do
-          execute(:kill, "-TTOU `cat  #{fetch(:puma_pid)}`")
+          puma_pid = capture("cat  #{fetch(:puma_pid)}")
+          execute(:kill, "-TTOU #{puma_pid}")
         end
       end
     end

--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -4,7 +4,7 @@ directory '<%= current_path %>'
 rackup "<%=fetch(:puma_rackup)%>"
 environment '<%= fetch(:puma_env) %>'
 <% if fetch(:puma_tag) %>
-  tag '<%= fetch(:puma_tag)%>'
+tag '<%= fetch(:puma_tag)%>'
 <% end %>
 pidfile "<%=fetch(:puma_pid)%>"
 state_path "<%=fetch(:puma_state)%>"


### PR DESCRIPTION

These are some minor issues that I encountered while digging into some errors that happened while trying to fix #208... since they are very minor, I don't think it's necessary to create more issues.

In any case, even if this PR is not merged, take them as reference for possible issues.

* Missing variables for `puma_tag` and `puma_control_app`. Added to the README.

* Included `PumaCommon` in `Puma::Workers` class definition (`puma:workers:count` didn't work because of `method_missing: puma_user`)

* Better logic in the `workers.rake` tasks. Capturing the pidfile with backticks inside a string wouldn't work as intended, it's better to cat the pidfile first and then interpolate inside the grep.

* Indentation for the `tag` field in the puma template was off.

