### PR TITLE
Add option to specify the location of SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_daemonize, true
     set :puma_plugins, []  #accept array of plugins
     set :puma_tag, fetch(:application)
+
+    set :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
+    set :nginx_flags, 'fail_timeout=0'
+    set :nginx_http_flags, fetch(:nginx_flags)
+    set :nginx_server_name, "localhost #{fetch(:application)}.local"
+    set :nginx_sites_available_path, '/etc/nginx/sites-available'
+    set :nginx_sites_enabled_path, '/etc/nginx/sites-enabled'
+    set :nginx_socket_flags, fetch(:nginx_flags)
+    set :nginx_ssl_certificate, "/etc/ssl/certs/{fetch(:nginx_config_name)}.crt"
+    set :nginx_ssl_certificate_key, "/etc/ssl/private/{fetch(:nginx_config_name)}.key"
     set :nginx_use_ssl, false
 ```
 

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -22,8 +22,16 @@ server {
 <% if fetch(:nginx_use_ssl) -%>
   listen 443;
   ssl on;
+<% if fetch(:nginx_ssl_certificate) -%>
+  ssl_certificate <%= fetch(:nginx_ssl_certificate) %>;
+<% else -%>
   ssl_certificate /etc/ssl/certs/<%= fetch(:nginx_config_name) %>.crt;
+<% end -%>
+<% if fetch(:nginx_ssl_certificate_key) -%>
+  ssl_certificate_key <%= fetch(:nginx_ssl_certificate_key) %>;
+<% else -%>
   ssl_certificate_key /etc/ssl/private/<%= fetch(:nginx_config_name) %>.key;
+<% end -%>
 <% else -%>
   listen 80;
 <% end -%>


### PR DESCRIPTION
If your SSL certificates are located somewhere else than
`/etc/ssl/certs/` and `/etc/ssl/private/` respectively, you can
use the options `:nginx_ssl_certificate` and
`:nginx_ssl_certificate_key` to specify their location.