### PR TITLE
Wait for Monit to be reloaded

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -8,6 +8,8 @@ namespace :puma do
         git_plugin.template_puma 'puma_monit.conf', "#{fetch(:tmp_dir)}/monit.conf", role
         git_plugin.sudo_if_needed "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:puma_monit_conf_dir)}"
         git_plugin.sudo_if_needed "#{fetch(:puma_monit_bin)} reload"
+        # Wait for Monit to be reloaded
+        sleep 1
       end
     end
 


### PR DESCRIPTION
Hi @seuros,

I just started to use Monit.
I noticed there is task puma:monit:config which is called when there is no process to monitor.
The task reloads Monit which is fine but it seems like Monit doesn't have enough time to fully reload.
That is why I have the following error:

```
00:20 puma:monit:monitor
      01 sudo /usr/bin/monit monitor puma_orip_bot_staging
      01 [sudo] password for deployer:
      01
      01 There is no service named "puma_orip_bot_staging"
00:20 puma:monit:config
      Uploading /tmp/monit.conf 100.0%
      01 sudo mv /tmp/monit.conf /etc/monit/conf.d/puma_orip_bot_staging.conf
      01 [sudo] password for deployer:
      01
    ✔ 01 deployer@xxx.xxx.xxx.xxx 0.058s
      02 sudo /usr/bin/monit reload
      02 [sudo] password for deployer:
      02
      02 Reinitializing monit daemon
      02
    ✔ 02 deployer@xxx.xxx.xxx.xxx 0.059s
      03 sudo /usr/bin/monit monitor puma_orip_bot_staging
      03 [sudo] password for deployer:
      03
      03 There is no service named "puma_orip_bot_staging"
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as deployer@xxx.xxx.xxx.xxx: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "puma_orip_bot_staging"
sudo stderr: Nothing written

SSHKit::Command::Failed: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "puma_orip_bot_staging"
sudo stderr: Nothing written

SSHKit::Command::Failed: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "puma_orip_bot_staging"
sudo stderr: Nothing written

Tasks: TOP => puma:monit:monitor
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as deployer@xxx.xxx.xxx.xxx: sudo exit status: 1
sudo stdout: [sudo] password for deployer:
There is no service named "puma_orip_bot_staging"
sudo stderr: Nothing written
```

With this little sleep 1 Monit is getting reloaded and I have no error.
The solution seems to be dirty but it works...

P. S.
I created the exact same [PR](https://github.com/seuros/capistrano-sidekiq/pull/170) for capistrano-sidekiq gem because I had similar issue there. But capistrano-sidekiq reposity seems to be less active than this one.