### PR TITLE
monit wait until not monitored

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -32,7 +32,7 @@ namespace :puma do
           git_plugin.sudo_if_needed "#{fetch(:puma_monit_bin)} unmonitor #{git_plugin.puma_monit_service_name}"
           git_plugin.wait_until_not_monitored
         rescue
-          warn "ERROR: #{$!.message}"
+          # no worries here (still no monitoring)
         end
       end
     end

--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -30,8 +30,9 @@ namespace :puma do
       on roles(fetch(:puma_role)) do
         begin
           git_plugin.sudo_if_needed "#{fetch(:puma_monit_bin)} unmonitor #{git_plugin.puma_monit_service_name}"
+          git_plugin.wait_until_not_monitored
         rescue
-          # no worries here (still no monitoring)
+          warn "ERROR: #{$!.message}"
         end
       end
     end


### PR DESCRIPTION
When I run `cap production deploy` for a very simple project, `deploy:symlink:release` can be finished in 20 seconds, monit unmonitor will not change progress status to `Not mornitored`, then task `puma:monit:monitor` will get failed.

This fix can wait until monit unmonitor progress completely