### PR TITLE
Fix undefined method 'as' on Capistrano::Puma and 'execute' should be wrapped in an 'on' block

### DIFF
--- a/lib/capistrano/puma.rb
+++ b/lib/capistrano/puma.rb
@@ -8,7 +8,7 @@ module Capistrano
       if user == role.user
         block.call
       else
-        as user do
+        backend.as user do
           block.call
         end
       end

--- a/lib/capistrano/puma/monit.rb
+++ b/lib/capistrano/puma/monit.rb
@@ -24,7 +24,10 @@ module Capistrano
       if fetch(:puma_monit_use_sudo)
         backend.sudo command
       else
-        backend.execute command
+        puma_role = fetch(:puma_role)
+        backend.on(puma_role) do
+          backend.execute command
+        end
       end
     end
   end


### PR DESCRIPTION
This PR should fix the following issues:

* When deploying as a different user than the one that must run ```puma```

> NoMethodError: undefined method `as' for #<Capistrano::Puma:0x007fde85295840>

which is reported here: https://github.com/seuros/capistrano-puma/issues/229

* When using monit to monitor the puma process

> Warning: `execute' should be wrapped in an `on' scope in /Users/daniel/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/capistrano-3.8.0/lib/capistrano/dsl.rb:38.
> 
>   task :example do
>     on roles(:app) do
>       execute 'whoami'
>     end
>   end
> 
> (Backtrace restricted to imported tasks)
> cap aborted!
> SSHKit::Runner::ExecuteError: Exception while executing on host *: Exception while executing on host *: undefined method `execute' for main:Object
> 
> NoMethodError: undefined method `execute' for main:Object
> 
> Tasks: TOP => puma:monit:monitor
