### PR TITLE
Use `$host` to prevent forgery

### DIFF
--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -47,7 +47,7 @@ server {
 
   location @puma_<%= fetch(:nginx_config_name) %> {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_redirect off;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Use `$host` instead of `$http_host` to prevent header Host forgery.
https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md