### PR TITLE
Force SSL/LTS with return directive

### DIFF
--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -14,7 +14,7 @@ end
 server {
   listen 80;
   server_name <%= fetch(:nginx_server_name) %>;
-  rewrite ^(.*) https://$host$1 permanent;
+  return 301 https://$host$1$request_uri;
 }
 <% end -%>
 


### PR DESCRIPTION
Force SSL/LTS with return directive

NGINX recommends the return directive over regular expressions.
The return directive is simpler to understand and faster to
execute than the regular expression.

Ref
[1]: https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/#taxing-rewrites
[2]: https://www.nginx.com/blog/creating-nginx-rewrite-rules/
Section Example - Forcing all Requests to Use SSL/TLS