### PR TITLE
Fix jungle setup for debian

### DIFF
--- a/lib/capistrano/puma/jungle.rb
+++ b/lib/capistrano/puma/jungle.rb
@@ -13,16 +13,10 @@ module Capistrano
 
     def debian_install(role)
       template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", role
-      execute "chmod +x #{fetch(:tmp_dir)}/puma"
-      sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
-      sudo 'update-rc.d -f puma defaults'
     end
 
     def rhel_install(role)
       template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma", role
-      execute "chmod +x #{fetch(:tmp_dir)}/puma"
-      sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
-      sudo 'chkconfig --add puma'
     end
   end
 end

--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -10,10 +10,16 @@ namespace :puma do
         sudo "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
         if test '[ -f /etc/redhat-release ]'
           #RHEL flavor OS
-          git_plugin.rhel_install(role)
+          template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma", role
+          execute "chmod +x #{fetch(:tmp_dir)}/puma"
+          sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
+          sudo 'chkconfig --add puma'
         elsif test '[ -f /etc/lsb-release ]'
           #Debian flavor OS
-          git_plugin.debian_install(role)
+          template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", role
+          execute "chmod +x #{fetch(:tmp_dir)}/puma"
+          sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
+          sudo 'update-rc.d -f puma defaults'
         else
           #Some other OS
           error 'This task is not supported for your OS'

--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -38,7 +38,11 @@ namespace :puma do
     desc 'Add current project to the jungle'
     task :add do
       on roles(fetch(:puma_role)) do|role|
-        sudo "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)}"
+        begin
+          sudo "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)}"
+        rescue => error
+          warn error
+        end
       end
     end
 

--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -10,13 +10,13 @@ namespace :puma do
         sudo "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
         if test '[ -f /etc/redhat-release ]'
           #RHEL flavor OS
-          template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma", role
+          Capistrano::PumaCommon.template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma", role
           execute "chmod +x #{fetch(:tmp_dir)}/puma"
           sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
           sudo 'chkconfig --add puma'
         elsif test '[ -f /etc/lsb-release ]'
           #Debian flavor OS
-          template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", role
+          Capistrano::PumaCommon.template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", role
           execute "chmod +x #{fetch(:tmp_dir)}/puma"
           sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
           sudo 'update-rc.d -f puma defaults'

--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -10,13 +10,13 @@ namespace :puma do
         sudo "mv #{fetch(:tmp_dir)}/run-puma #{fetch(:puma_run_path)}"
         if test '[ -f /etc/redhat-release ]'
           #RHEL flavor OS
-          Capistrano::PumaCommon.template_puma 'puma-rpm', "#{fetch(:tmp_dir)}/puma", role
+          git_plugin.rhel_install(role)
           execute "chmod +x #{fetch(:tmp_dir)}/puma"
           sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
           sudo 'chkconfig --add puma'
         elsif test '[ -f /etc/lsb-release ]'
           #Debian flavor OS
-          Capistrano::PumaCommon.template_puma 'puma-deb', "#{fetch(:tmp_dir)}/puma", role
+          git_plugin.debian_install(role)
           execute "chmod +x #{fetch(:tmp_dir)}/puma"
           sudo "mv #{fetch(:tmp_dir)}/puma /etc/init.d/puma"
           sudo 'update-rc.d -f puma defaults'

--- a/lib/capistrano/templates/puma-deb.erb
+++ b/lib/capistrano/templates/puma-deb.erb
@@ -1,17 +1,16 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides: puma
-# Required-Start: $remote_fs $syslog
-# Required-Stop: $remote_fs $syslog
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
-# Short-Description: Example initscript
-# Description: This file should be used to construct scripts to be
-# placed in /etc/init.d.
+# Provides:          puma 
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Puma web server
+# Description:       A ruby web server built for concurrency http://puma.io
+#                    initscript to be placed in /etc/init.d.
 ### END INIT INFO
 
-# Author: Darío Javier Cravero <'dario@exordo.com'>
-# Modified by: Abdelkader Boudih <'terminale@gmail.com'>
+# Author: Darío Javier Cravero <dario@exordo.com>
 #
 # Do NOT "set -e"
 
@@ -24,6 +23,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 CONFIG=<%=fetch(:puma_jungle_conf)%>
 JUNGLE=`cat $CONFIG`
 RUNPUMA=<%=fetch(:puma_run_path)%>
+USE_LOCAL_BUNDLE=0
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh
@@ -33,22 +33,13 @@ RUNPUMA=<%=fetch(:puma_run_path)%>
 . /lib/lsb/init-functions
 
 #
-# Function that starts the jungle
+# Function that starts the jungle 
 #
 do_start() {
   log_daemon_msg "=> Running the jungle..."
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
-    user=`echo $i | cut -d , -f 2`
-    config_file=`echo $i | cut -d , -f 3`
-    if [ "$config_file" = "" ]; then
-      config_file="$dir/config/puma.rb"
-    fi
-    log_file=`echo $i | cut -d , -f 4`
-    if [ "$log_file" = "" ]; then
-      log_file="$dir/log/puma.log"
-    fi
-    do_start_one $dir $user $config_file $log_file
+    do_start_one $dir
   done
 }
 
@@ -58,21 +49,41 @@ do_start_one() {
     PID=`cat $PIDFILE`
     # If the puma isn't running, run it, otherwise restart it.
     if [ "`ps -A -o pid= | grep -c $PID`" -eq 0 ]; then
-      do_start_one_do $1 $2
+      do_start_one_do $1
     else
-      do_restart_one $1 $2
+      do_restart_one $1
     fi
   else
-    do_start_one_do $1 $2
+    do_start_one_do $1
   fi
 }
 
 do_start_one_do() {
-  log_daemon_msg "--> Woke up puma $1"
-  log_daemon_msg "user $2"
-  log_daemon_msg "log to $4"
-  log_daemon_msg "start-stop-daemon --verbose --start --chdir $1 --chuid $2 --background --exec $RUNPUMA $1 "
-  start-stop-daemon --verbose --start --chdir $1 --chuid $2 --background --exec $RUNPUMA -- $1
+  i=`grep $1 $CONFIG`
+  dir=`echo $i | cut -d , -f 1`
+  user=`echo $i | cut -d , -f 2`
+  config_file=`echo $i | cut -d , -f 3`
+  if [ "$config_file" = "" ]; then
+    config_file="$dir/config/puma.rb"
+  fi
+  log_file=`echo $i | cut -d , -f 4`
+  if [ "$log_file" = "" ]; then
+    log_file="$dir/log/puma.log"
+  fi
+  environment=`echo $i | cut -d , -f 5`
+
+  log_daemon_msg "--> Woke up puma $dir"
+  log_daemon_msg "user $user"
+  log_daemon_msg "log to $log_file"
+
+  if [ ! -z "$environment" ]; then
+    for e in $(echo "$environment" | tr ';' '\n'); do
+        log_daemon_msg "environment $e"
+        v=${e%%\=*} ;  eval "$e" ; export $v
+    done
+  fi
+
+  start-stop-daemon --verbose --start --chdir $dir --chuid $user --background --exec $RUNPUMA -- $dir $config_file $log_file
 }
 
 #
@@ -82,8 +93,7 @@ do_stop() {
   log_daemon_msg "=> Putting all the beasts to bed..."
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
-    user=`echo $i | cut -d , -f 2`
-    do_stop_one $dir $user
+    do_stop_one $dir
   done
 }
 #
@@ -99,7 +109,11 @@ do_stop_one() {
       log_daemon_msg "---> Puma $1 isn't running."
     else
       log_daemon_msg "---> About to kill PID `cat $PIDFILE`"
-      su - $2 -c "pumactl --state $STATEFILE stop"
+      if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
+        cd $1 && bundle exec pumactl --state $STATEFILE stop
+      else
+        pumactl --state $STATEFILE stop
+      fi
       # Many daemons don't delete their pidfiles when they exit.
       rm -f $PIDFILE $STATEFILE
     fi
@@ -110,13 +124,12 @@ do_stop_one() {
 }
 
 #
-# Function that restarts the jungle
+# Function that restarts the jungle 
 #
 do_restart() {
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
-    user=`echo $i | cut -d , -f 2`
-    do_restart_one $dir $user
+    do_restart_one $dir
   done
 }
 
@@ -125,39 +138,52 @@ do_restart() {
 #
 do_restart_one() {
   PIDFILE=$1/tmp/pids/puma.pid
-  i=`grep $1 $CONFIG`
-  dir=`echo $i | cut -d , -f 1`
 
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to restart puma $1"
-    su - $2 -c "pumactl --state $dir/tmp/pids/puma.state restart"
-    # kill -s USR2 `cat $PIDFILE`
+    kill -s USR2 `cat $PIDFILE`
     # TODO Check if process exist
   else
     log_daemon_msg "--> Your puma was never playing... Let's get it out there first"
-    user=`echo $i | cut -d , -f 2`
-    config_file=`echo $i | cut -d , -f 3`
-    if [ "$config_file" = "" ]; then
-      config_file="$dir/config/puma.rb"
-      do_start_one $dir $user $config_file
-    fi
-    log_file=`echo $i | cut -d , -f 4`
-    if [ "$log_file" = "" ]; then
-      log_file="$dir/log/puma.log"
-    fi
-    do_start_one $dir $user $config_file $log_file
+    do_start_one $1
   fi
-  return 0
+	return 0
 }
 
 #
-# Function that statuss the jungle
+# Function that phased restarts the jungle
+#
+do_phased_restart() {
+  for i in $JUNGLE; do
+    dir=`echo $i | cut -d , -f 1`
+    do_phased_restart_one $dir
+  done
+}
+
+#
+# Function that sends a SIGUSR1 to the daemon/service
+#
+do_phased_restart_one() {
+  PIDFILE=$1/tmp/pids/puma.pid
+
+  if [ -e $PIDFILE ]; then
+    log_daemon_msg "--> About to restart puma $1"
+    kill -s USR1 `cat $PIDFILE`
+    # TODO Check if process exist
+  else
+    log_daemon_msg "--> Your puma was never playing... Let's get it out there first"
+    do_start_one $1
+  fi
+	return 0
+}
+
+#
+# Function that statuss the jungle 
 #
 do_status() {
   for i in $JUNGLE; do
     dir=`echo $i | cut -d , -f 1`
-    user=`echo $i | cut -d , -f 2`
-    do_status_one $dir $user
+    do_status_one $dir
   done
 }
 
@@ -168,16 +194,20 @@ do_status_one() {
   PIDFILE=$1/tmp/pids/puma.pid
   i=`grep $1 $CONFIG`
   dir=`echo $i | cut -d , -f 1`
-
+  
   if [ -e $PIDFILE ]; then
     log_daemon_msg "--> About to status puma $1"
-
-    su - $2 -c "pumactl --state $dir/tmp/pids/puma.state stats "
-
+    if [ "$USE_LOCAL_BUNDLE" -eq 1 ]; then
+      cd $1 && bundle exec pumactl --state $dir/tmp/pids/puma.state stats
+    else
+      pumactl --state $dir/tmp/pids/puma.state stats
+    fi
+    # kill -s USR2 `cat $PIDFILE`
+    # TODO Check if process exist
   else
-    log_daemon_msg "--> $1 isn't there :(..."
+    log_daemon_msg "--> $1 isn't there :(..." 
   fi
-  return 0
+	return 0
 }
 
 do_add() {
@@ -188,7 +218,7 @@ do_add() {
       str=$1
     else
       echo "The app is already being managed. Remove it if you want to update its config."
-      exit 0
+      exit 1 
     fi
   else
     echo "The directory $1 doesn't exist."
@@ -215,7 +245,12 @@ do_add() {
     str="$str,$4"
   fi
 
-  # Add it to the jungle
+  # Environment variables
+  if [ "$5" != "" ]; then
+    str="$str,$5"
+  fi
+
+  # Add it to the jungle 
   echo $str >> $CONFIG
   log_daemon_msg "Added a Puma to the jungle: $str. You still have to start it though."
 }
@@ -232,6 +267,49 @@ do_remove() {
   fi
 }
 
+config_bundler() {
+  HOME="$(eval echo ~$(id -un))"
+
+  if [ -d "$1/.rbenv/bin" ]; then
+    PATH="$1/.rbenv/bin:$1/.rbenv/shims:$1"
+    eval "$(rbenv init -)"
+    USE_LOCAL_BUNDLE=1
+    return 0
+
+  elif [ -d "/usr/local/rbenv/bin" ]; then
+    PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+    eval "$(rbenv init -)"
+    USE_LOCAL_BUNDLE=1
+    return 0
+
+  elif [ -d "$HOME/.rbenv/bin" ]; then
+    PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+    eval "$(rbenv init -)"
+    USE_LOCAL_BUNDLE=1
+    return 0
+
+  # TODO: test rvm
+  # elif [ -f  /etc/profile.d/rvm.sh ]; then
+  #   source /etc/profile.d/rvm.sh
+  # elif [ -f /usr/local/rvm/scripts/rvm ]; then
+  #   source /etc/profile.d/rvm.sh
+  # elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+  #   source "$HOME/.rvm/scripts/rvm"
+  # TODO: don't know what to do with chruby
+  # elif [ -f /usr/local/share/chruby/chruby.sh ]; then
+  #   source /usr/local/share/chruby/chruby.sh
+  #   if [ -f /usr/local/share/chruby/auto.sh ]; then
+  #     source /usr/local/share/chruby/auto.sh
+  #   fi
+  # if you aren't using auto, set your version here
+  # chruby 2.0.0
+  fi
+
+  return 1
+}
+
+config_bundler
+
 case "$1" in
   start)
     [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
@@ -240,18 +318,12 @@ case "$1" in
     else
       i=`grep $2 $CONFIG`
       dir=`echo $i | cut -d , -f 1`
-      user=`echo $i | cut -d , -f 2`
-      config_file=`echo $i | cut -d , -f 3`
-      if [ "$config_file" = "" ]; then
-        config_file="$dir/config/puma.rb"
-
-        do_start_one $dir $user $config_file
-      fi
-      case "$?" in
-        0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-        2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-      esac
+      do_start_one $dir
     fi
+    case "$?" in
+      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
   ;;
   stop)
     [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
@@ -296,11 +368,25 @@ case "$1" in
       2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
     esac
   ;;
+  phased-restart)
+    log_daemon_msg "Restarting (phased) $DESC" "$NAME"
+    if [ "$#" -eq 1 ]; then
+      do_phased_restart
+    else
+      i=`grep $2 $CONFIG`
+      dir=`echo $i | cut -d , -f 1`
+      do_phased_restart_one $dir
+    fi
+    case "$?" in
+      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+    esac
+  ;;
   add)
     if [ "$#" -lt 3 ]; then
-      echo "Please, specifiy the app's directory and the user that will run it at least."
-      echo " Usage: $SCRIPTNAME add /path/to/app user /path/to/app/config/puma.rb /path/to/app/config/log/puma.log"
-      echo " config and log are optionals."
+      echo "Please, specify the app's directory and the user that will run it at least."
+      echo "  Usage: $SCRIPTNAME add /path/to/app user /path/to/app/config/puma.rb /path/to/app/config/log/puma.log"
+      echo "    config and log are optionals."
       exit 1
     else
       do_add $2 $3 $4 $5
@@ -324,13 +410,12 @@ case "$1" in
   ;;
   *)
     echo "Usage:" >&2
-    echo " Run the jungle: $SCRIPTNAME {start|stop|status|restart}" >&2
-    echo " Add a Puma: $SCRIPTNAME add /path/to/app user /path/to/app/config/puma.rb /path/to/app/config/log/puma.log"
-    echo " config and log are optionals."
-    echo " Remove a Puma: $SCRIPTNAME remove /path/to/app"
-    echo " On a Puma: $SCRIPTNAME {start|stop|status|restart} PUMA-NAME" >&2
+    echo "  Run the jungle: $SCRIPTNAME {start|stop|status|restart|phased-restart}" >&2
+    echo "  Add a Puma: $SCRIPTNAME add /path/to/app user /path/to/app/config/puma.rb /path/to/app/config/log/puma.log"
+    echo "    config and log are optionals."
+    echo "  Remove a Puma: $SCRIPTNAME remove /path/to/app"
+    echo "  On a Puma: $SCRIPTNAME {start|stop|status|restart|phased-restart} PUMA-NAME" >&2
     exit 3
   ;;
 esac
 :
-

--- a/lib/capistrano/templates/run-puma.erb
+++ b/lib/capistrano/templates/run-puma.erb
@@ -1,9 +1,18 @@
 #!/bin/bash
-app=$1;
-cd $app || exit 1
 
-if [ -e Gemfile ]; then
-    exec <%= fetch(:puma_user) ? "sudo -u #{puma_user(@role)}" : '' %> sh -c "exec bundle exec puma -C <%= fetch(:puma_conf) %> --daemon"
-else
-    exec <%= fetch(:puma_user) ? "sudo -u #{puma_user(@role)}" : '' %> sh -c "exec puma -C <%= fetch(:puma_conf) %> --daemon"
+# on system boot, and root have no rbenv installed,
+#   after start-stop-daemon switched to current user, we have to init rbenv
+if [ -d "$HOME/.rbenv/bin" ]; then
+  PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+  eval "$(rbenv init -)"
+elif [ -d "/usr/local/rbenv/bin" ]; then
+  PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+  eval "$(rbenv init -)"
+elif [ -f /usr/local/rvm/scripts/rvm ]; then
+  source /etc/profile.d/rvm.sh
+elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+  source "$HOME/.rvm/scripts/rvm"
 fi
+
+app=$1; config=$2; log=$3;
+cd $app && exec bundle exec puma -C $config 2>&1 >> $log

--- a/lib/capistrano/templates/run-puma.erb
+++ b/lib/capistrano/templates/run-puma.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# source ENV variables manually
+. /etc/environment
 # on system boot, and root have no rbenv installed,
 #   after start-stop-daemon switched to current user, we have to init rbenv
 if [ -d "$HOME/.rbenv/bin" ]; then


### PR DESCRIPTION
Fix `Warning: `execute' should be wrapped ` in jungle:setup task
Update run-puma to support ruby managment systems.
Update puma-deb from puma repository.