### PR TITLE
Added shared puma conf as argument to jungle:add

### DIFF
--- a/lib/capistrano/tasks/jungle.rake
+++ b/lib/capistrano/tasks/jungle.rake
@@ -39,7 +39,7 @@ namespace :puma do
     task :add do
       on roles(fetch(:puma_role)) do|role|
         begin
-          sudo "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)}"
+          sudo "/etc/init.d/puma add '#{current_path}' #{fetch(:puma_user, role.user)} '#{fetch(:puma_conf)}'"
         rescue => error
           warn error
         end


### PR DESCRIPTION
Explicitly making it refer to the puma config in shared folder so that it won't go and look at the one I use in development environment. 