### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :nginx_sites_available_path, '/etc/nginx/sites-available'
     set :nginx_sites_enabled_path, '/etc/nginx/sites-enabled'
     set :nginx_socket_flags, fetch(:nginx_flags)
-    set :nginx_ssl_certificate, "/etc/ssl/certs/{fetch(:nginx_config_name)}.crt"
-    set :nginx_ssl_certificate_key, "/etc/ssl/private/{fetch(:nginx_config_name)}.key"
+    set :nginx_ssl_certificate, "/etc/ssl/certs/#{fetch(:nginx_config_name)}.crt"
+    set :nginx_ssl_certificate_key, "/etc/ssl/private/#{fetch(:nginx_config_name)}.key"
     set :nginx_use_ssl, false
 ```
 


### PR DESCRIPTION
Typo. Missed `#` for string interpolation.