### PR TITLE
Wrong path to puma config fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To upload puma config use:
 ```ruby
 cap production puma:config
 ```
-By default the file located in  `shared/puma.config`
+By default the file located in  `shared/puma.rb`
 
 
 Ensure that `tmp/pids` and ` tmp/sockets log` are shared (via `linked_dirs`):


### PR DESCRIPTION
As described in README below fixed string default config file name (path) is:
 set :puma_conf, "#{shared_path}/**puma.rb**", not puma.config