### PR TITLE
Nginx tasks should use execute over sudo

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -6,8 +6,8 @@ namespace :puma do
     on roles(fetch(:puma_nginx, :web)) do |role|
       git_plugin.puma_switch_user(role) do
         git_plugin.template_puma('nginx_conf', "/tmp/nginx_#{fetch(:nginx_config_name)}", role)
-        sudo :mv, "/tmp/nginx_#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)}"
-        sudo :ln, '-fs', "#{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_enabled_path)}/#{fetch(:nginx_config_name)}"
+        execute :mv, "/tmp/nginx_#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)}"
+        execute :ln, '-fs', "#{fetch(:nginx_sites_available_path)}/#{fetch(:nginx_config_name)} #{fetch(:nginx_sites_enabled_path)}/#{fetch(:nginx_config_name)}"
       end
     end
   end


### PR DESCRIPTION
Since capistrano suggests [1] a non-sudo-user deployment, we should not try to run sudo when moving nginx config files.

[1] http://capistranorb.com/documentation/getting-started/authentication-and-authorisation/

