### PR TITLE
special case: setting X-Forwarded-Proto https even if ngnix is not using SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :nginx_ssl_certificate, "/etc/ssl/certs/#{fetch(:nginx_config_name)}.crt"
     set :nginx_ssl_certificate_key, "/etc/ssl/private/#{fetch(:nginx_config_name)}.key"
     set :nginx_use_ssl, false
+    set :nginx_downstream_uses_ssl, false
 ```
 
 __Notes:__ If you are setting values for variables that might be used by other plugins, use `append` instead of `set`. For example:

--- a/lib/capistrano/puma/nginx.rb
+++ b/lib/capistrano/puma/nginx.rb
@@ -11,6 +11,7 @@ module Capistrano
       set_if_empty :nginx_http_flags, fetch(:nginx_flags)
       set_if_empty :nginx_socket_flags, fetch(:nginx_flags)
       set_if_empty :nginx_use_ssl, false
+      set_if_empty :nginx_downstream_uses_ssl, false
     end
 
     def define_tasks

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -54,7 +54,11 @@ server {
 <% if fetch(:nginx_use_ssl) -%>
     proxy_set_header X-Forwarded-Proto https;
 <% else -%>
+  <% if fetch(:nginx_downstream_uses_ssl) -%>
+    proxy_set_header X-Forwarded-Proto https;
+  <% else -%>
     proxy_set_header X-Forwarded-Proto http;
+  <% end -%>
 <% end -%>
     proxy_pass http://puma_<%= fetch(:nginx_config_name) %>;
     # limit_req zone=one;


### PR DESCRIPTION
setting X-Forwarded-Proto https if ngnix is not using SSL, however, there is SSL termination going on upstream (e.g. AWS ELB)