### PR TITLE
New feature: puma rolling restart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_tag, fetch(:application)
     set :puma_restart_command, 'bundle exec puma'
 
+    # Rolling restart
+    set :puma_rolling_restart, false
+    set :puma_rolling_wait, 10
+    set :puma_rolling_groups, 1
+
     set :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
     set :nginx_flags, 'fail_timeout=0'
     set :nginx_http_flags, fetch(:nginx_flags)

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -59,7 +59,8 @@ namespace :puma do
   %w[phased-restart restart].map do |command|
     desc "#{command} puma"
     task command do
-      on roles (fetch(:puma_role)) do |role|
+      options = restart_options(command)
+      on roles(fetch(:puma_role)), options do |role|
         within current_path do
           git_plugin.puma_switch_user(role) do
             with rack_env: fetch(:puma_env) do


### PR DESCRIPTION
`puma rolling restart` restart puma cluster servers one by one. It will lighten the impact of deployment when restarting puma.
`puma phased-restart` is smart. But there is a limitation that preload_app must be true. `puma rolling restart` is another way.

Usage:
    Add configuration to `deploy.rb`
 
    # Rolling restart
    set :puma_rolling_restart, false   # Enable rolling restart or not. Default is false.
    set :puma_rolling_wait, 10            # Waiting seconds when rolling_restart
    set :puma_rolling_groups, 1         # Rolling restart by group. Default is 1.
