### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ To prevent loading the hooks of the plugin, add false to the load_hooks param.
     install_plugin Capistrano::Puma::Monit, load_hooks: false  # Monit tasks without hooks
 ```
 
+To make it work with rvm, rbenv and chruby, install the plugin after corresponding library inclusion.
+```ruby
+    # Capfile
+    
+    require 'capistrano/rvm    
+    require 'capistrano/puma'
+    install_plugin Capistrano::Puma
+```
+
 ### Config
 
 To list available tasks use `cap -T`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To make it work with rvm, rbenv and chruby, install the plugin after correspondi
 ```ruby
     # Capfile
     
-    require 'capistrano/rvm    
+    require 'capistrano/rbenv'   
     require 'capistrano/puma'
     install_plugin Capistrano::Puma
 ```


### PR DESCRIPTION
When you install the plugin before capistrano/rvm it appends `puma` and `pumactl` to `rvm_map_bins` variable, but then capistrano/rvm rewrites it. To make it work with rvm the plugin should be install after capistrano/rvm