### PR TITLE
Use HTTP 1.1 for proxying

### DIFF
--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -46,6 +46,7 @@ server {
   error_page 503 @503;
 
   location @puma_<%= fetch(:nginx_config_name) %> {
+    proxy_http_version 1.1;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_redirect off;


### PR DESCRIPTION
HTTP 1.0 is the default, which doesn't support chunked transfer encoding. This leads to ActiveStorage downloads being truncated.

https://stackoverflow.com/questions/53374839/rails-5-2-1-activestorage-file-downloads-with-nginx-puma-are-truncated/53410174#53410174