### PR TITLE
Get the monit commands to work when chruby is used

### DIFF
--- a/lib/capistrano/templates/puma_monit.conf.erb
+++ b/lib/capistrano/templates/puma_monit.conf.erb
@@ -3,5 +3,5 @@
 #
 check process <%= puma_monit_service_name %>
   with pidfile "<%= fetch(:puma_pid) %>"
-  start program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
-  stop program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"
+  start program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -l -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:puma] %> -C <%= fetch(:puma_conf) %> --daemon'"
+  stop program = "/usr/bin/sudo -iu <%= puma_user(@role) %> /bin/bash -l -c 'cd <%= current_path %> && <%= SSHKit.config.command_map[:pumactl] %> -S <%= fetch(:puma_state) %> stop'"


### PR DESCRIPTION
Use the -l option to make bash act as if it had been invoked as a login shell.