### PR TITLE
Fixed call parameter

### DIFF
--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -40,7 +40,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]"
                 if test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
-                  execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
+                  execute :pumactl, "-S #{fetch(:puma_state)} -C #{fetch(:puma_conf)} #{command}"
                 else
                   # delete invalid pid file , process is not running.
                   execute :rm, fetch(:puma_pid)
@@ -65,7 +65,7 @@ namespace :puma do
             with rack_env: fetch(:puma_env) do
               if test "[ -f #{fetch(:puma_pid)} ]" and test :kill, "-0 $( cat #{fetch(:puma_pid)} )"
                 # NOTE pid exist but state file is nonsense, so ignore that case
-                execute :pumactl, "-S #{fetch(:puma_state)} -F #{fetch(:puma_conf)} #{command}"
+                execute :pumactl, "-S #{fetch(:puma_state)} -C #{fetch(:puma_conf)} #{command}"
               else
                 # Puma is not running or state file is not present : Run it
                 invoke 'puma:start'


### PR DESCRIPTION
Config files were not read due to a typo in the (or possibly outdated) command line parameters.