### PR TITLE
Allow to set on_worker_shutdown hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_plugins, []  #accept array of plugins
     set :puma_tag, fetch(:application)
     set :puma_restart_command, 'bundle exec puma'
+    set :puma_on_worker_shutdown, false
 
     set :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
     set :nginx_flags, 'fail_timeout=0'

--- a/lib/capistrano/templates/puma.rb.erb
+++ b/lib/capistrano/templates/puma.rb.erb
@@ -52,3 +52,9 @@ on_worker_boot do
   end
 end
 <% end %>
+
+<% if fetch(:puma_on_worker_shutdown) %>
+on_worker_shutdown do
+  <%= fetch(:puma_on_worker_shutdown) %>
+end
+<% end %>


### PR DESCRIPTION
In this PR I added an option to set `on_worker_shutdown` hook to the puma config template.