### PR TITLE
Update nginx template

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :nginx_ssl_certificate, "/etc/ssl/certs/#{fetch(:nginx_config_name)}.crt"
     set :nginx_ssl_certificate_key, "/etc/ssl/private/#{fetch(:nginx_config_name)}.key"
     set :nginx_use_ssl, false
+    set :nginx_use_http2, true
     set :nginx_downstream_uses_ssl, false
 ```
 

--- a/lib/capistrano/puma/nginx.rb
+++ b/lib/capistrano/puma/nginx.rb
@@ -11,6 +11,7 @@ module Capistrano
       set_if_empty :nginx_http_flags, fetch(:nginx_flags)
       set_if_empty :nginx_socket_flags, fetch(:nginx_flags)
       set_if_empty :nginx_use_ssl, false
+      set_if_empty :nginx_use_http2, true
       set_if_empty :nginx_downstream_uses_ssl, false
     end
 

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -20,8 +20,11 @@ server {
 
 server {
 <% if fetch(:nginx_use_ssl) -%>
-  listen 443;
-  ssl on;
+  <% if fetch(:nginx_use_http2) -%>
+  listen 443 ssl http2;
+  <% else -%>
+  listen 443 ssl;
+  <% end -%>
 <% if fetch(:nginx_ssl_certificate) -%>
   ssl_certificate <%= fetch(:nginx_ssl_certificate) %>;
 <% else -%>


### PR DESCRIPTION
Update Nginx template:

- Move obsolete 'ssl' directive to the 'listen' directive instead [http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl)
- Add option to enable http2 for nginx with ssl [http://nginx.org/en/docs/http/ngx_http_v2_module.html](http://nginx.org/en/docs/http/ngx_http_v2_module.html)