### PR TITLE
Fix #301, Task "puma:smart_restart" not found

### DIFF
--- a/lib/capistrano/tasks/daemon.rake
+++ b/lib/capistrano/tasks/daemon.rake
@@ -63,4 +63,12 @@ namespace :puma do
       end
     end
   end
+
+  task :smart_restart do
+    if !fetch(:puma_preload_app) && fetch(:puma_workers, 0).to_i > 1
+      invoke 'puma:phased-restart'
+    else
+      invoke 'puma:restart'
+    end
+  end
 end


### PR DESCRIPTION
Seems is removed in 24b91a7e1fc9442f9630f1f684885a281feaf1ae original file `lib/capistrano/tasks/puma.rake`, but not add back at new file `lib/capistrano/tasks/daemon.rake`