### PR TITLE
Systemd user service manager and lingering

### DIFF
--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -11,9 +11,10 @@ module Capistrano
     end
 
     def set_defaults
-      set_if_empty :puma_systemd_conf_dir, '/etc/systemd/system'
       set_if_empty :puma_systemctl_bin, '/bin/systemctl'
       set_if_empty :puma_service_unit_name, 'puma'
+      set_if_empty :puma_service_unit_user, :system
+      set_if_empty :puma_enable_lingering, false
     end
   end
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -8,7 +8,7 @@ namespace :puma do
     task :config do
       on roles(fetch(:puma_role)) do |role|
         unit_filename = "#{fetch(:puma_service_unit_name)}.service"
-        git_plugin.template_puma unit_filename, "#{fetch(:tmp_dir)}/#{unit_filename}", role
+        git_plugin.template_puma "puma.service", "#{fetch(:tmp_dir)}/#{unit_filename}", role
         sudo "mv #{fetch(:tmp_dir)}/#{unit_filename} #{fetch(:puma_systemd_conf_dir)}"
         sudo "#{fetch(:puma_systemctl_bin)} daemon-reload"
       end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -9,51 +9,94 @@ namespace :puma do
       on roles(fetch(:puma_role)) do |role|
         unit_filename = "#{fetch(:puma_service_unit_name)}.service"
         git_plugin.template_puma "puma.service", "#{fetch(:tmp_dir)}/#{unit_filename}", role
-        sudo "mv #{fetch(:tmp_dir)}/#{unit_filename} #{fetch(:puma_systemd_conf_dir)}"
-        sudo "#{fetch(:puma_systemctl_bin)} daemon-reload"
+        systemd_path = fetch(:puma_systemd_conf_dir, git_plugin.fetch_systemd_unit_path)
+        if fetch(:puma_systemctl_user) == :system
+          sudo "mv #{fetch(:tmp_dir)}/#{unit_filename} #{systemd_path}"
+          sudo "#{fetch(:puma_systemctl_bin)} daemon-reload"
+        else
+          execute :mkdir, "-p", systemd_path
+          execute :mv, "#{fetch(:tmp_dir)}/#{unit_filename}", "#{systemd_path}"
+          execute fetch(:puma_systemctl_bin), "--user", "daemon-reload"
+        end
       end
     end
 
     desc 'Enable Puma systemd service'
     task :enable do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_systemctl_bin)} enable #{fetch(:puma_service_unit_name)}"
+        if fetch(:puma_systemctl_user) == :system
+          sudo "#{fetch(:puma_systemctl_bin)} enable #{fetch(:puma_service_unit_name)}"
+        else
+          execute "#{fetch(:puma_systemctl_bin)}", "--user", "enable", fetch(:puma_service_unit_name)
+          execute :loginctl, "enable-linger", fetch(:puma_lingering_user) if fetch(:puma_enable_lingering)
+        end
       end
     end
 
     desc 'Disable Puma systemd service'
     task :disable do
       on roles(fetch(:puma_role)) do
-        sudo "#{fetch(:puma_systemctl_bin)} disable #{fetch(:puma_service_unit_name)}"
+        if fetch(:puma_systemctl_user) == :system
+          sudo "#{fetch(:puma_systemctl_bin)} disable #{fetch(:puma_service_unit_name)}"
+        else
+          execute "#{fetch(:puma_systemctl_bin)}", "--user", "disable", fetch(:puma_service_unit_name)
+        end
       end
     end
+
   end
 
   desc 'Start Puma service via systemd'
   task :start do
     on roles(fetch(:puma_role)) do
-      sudo "#{fetch(:puma_systemctl_bin)} start #{fetch(:puma_service_unit_name)}"
+      if fetch(:puma_systemctl_user) == :system
+        sudo "#{fetch(:puma_systemctl_bin)} start #{fetch(:puma_service_unit_name)}"
+      else
+        execute "#{fetch(:puma_systemctl_bin)}", "--user", "start", fetch(:puma_service_unit_name)
+      end
     end
   end
 
   desc 'Stop Puma service via systemd'
   task :stop do
     on roles(fetch(:puma_role)) do
-      sudo "#{fetch(:puma_systemctl_bin)} stop #{fetch(:puma_service_unit_name)}"
+      if fetch(:puma_systemctl_user) == :system
+        sudo "#{fetch(:puma_systemctl_bin)} stop #{fetch(:puma_service_unit_name)}"
+      else
+        execute "#{fetch(:puma_systemctl_bin)}", "--user", "stop", fetch(:puma_service_unit_name)
+      end
     end
   end
 
   desc 'Restart Puma service via systemd'
   task :restart do
     on roles(fetch(:puma_role)) do
-      sudo "#{fetch(:puma_systemctl_bin)} restart #{fetch(:puma_service_unit_name)}"
+      if fetch(:puma_systemctl_user) == :system
+        sudo "#{fetch(:puma_systemctl_bin)} restart #{fetch(:puma_service_unit_name)}"
+      else
+        execute "#{fetch(:puma_systemctl_bin)}", "--user", "restart", fetch(:puma_service_unit_name)
+      end
     end
   end
 
   desc 'Get Puma service status via systemd'
   task :status do
     on roles(fetch(:puma_role)) do
-      sudo "#{fetch(:puma_systemctl_bin)} status #{fetch(:puma_service_unit_name)}"
+      if fetch(:puma_systemctl_user) == :system
+        sudo "#{fetch(:puma_systemctl_bin)} status #{fetch(:puma_service_unit_name)}"
+      else
+        execute "#{fetch(:puma_systemctl_bin)}", "--user", "status", fetch(:puma_service_unit_name)
+      end
     end
   end
+
+  def fetch_systemd_unit_path
+    if fetch(:puma_systemctl_user) == :system
+      "/etc/systemd/system/"
+    else
+      home_dir = backend.capture :pwd
+      File.join(home_dir, ".config", "systemd", "user")
+    end
+  end
+
 end

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-User=<%= puma_user(@role) %>
+<%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
 ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec puma -C <%= fetch(:puma_conf) %>
 ExecReload=/bin/kill -TSTP $MAINPID
@@ -15,4 +15,4 @@ StandardError=append:<%= fetch(:puma_error_log) %>
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=<%=(fetch(:puma_systemctl_user) == :system) ? "multi-user.target" : "default.target"%>


### PR DESCRIPTION
1. fix a problem when setting puma_service_unit_name different from the default value. Before it was unable to use the dafault erb template
2. add puma_service_unit_user config to manage system or user service manager
3. add puma_enable_lingering to anable lingering or not