### PR TITLE
Single name for systemd config template

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -8,7 +8,7 @@ namespace :puma do
     task :config do
       on roles(fetch(:puma_role)) do |role|
         unit_filename = "#{fetch(:puma_service_unit_name)}.service"
-        git_plugin.template_puma unit_filename, "#{fetch(:tmp_dir)}/#{unit_filename}", role
+        git_plugin.template_puma 'puma.service', "#{fetch(:tmp_dir)}/#{unit_filename}", role
         sudo "mv #{fetch(:tmp_dir)}/#{unit_filename} #{fetch(:puma_systemd_conf_dir)}"
         sudo "#{fetch(:puma_systemctl_bin)} daemon-reload"
       end


### PR DESCRIPTION
Rather than having to define a template per staging environment, use
`puma.service` as the template name to lookup.

Fixes seuros/capistrano-puma#305