### PR TITLE
Default systemd service name on multi-app host

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_plugins, []  #accept array of plugins
     set :puma_tag, fetch(:application)
     set :puma_restart_command, 'bundle exec puma'
+    set :puma_service_unit_name, "puma_#{fetch(:application)}_#{fetch(:stage)}"
 
     set :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
     set :nginx_flags, 'fail_timeout=0'

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -13,7 +13,7 @@ module Capistrano
     def set_defaults
       set_if_empty :puma_systemd_conf_dir, '/etc/systemd/system'
       set_if_empty :puma_systemctl_bin, '/bin/systemctl'
-      set_if_empty :puma_service_unit_name, 'puma'
+      set_if_empty :puma_service_unit_name, -> { "puma_#{fetch(:application)}_#{fetch(:stage)}" }
     end
   end
 end


### PR DESCRIPTION
Using a default systemd service name that is consistent with the default
names used in the nginx and monit plugins.

In combination with seuros/capistrano-puma#308, forms a zero-config
solution to seuros/capistrano-puma#305