### PR TITLE
Remove ExecStop from systemd unit file

### DIFF
--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -8,7 +8,6 @@ User=<%= puma_user(@role) %>
 WorkingDirectory=<%= current_path %>
 ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec puma -C <%= fetch(:puma_conf) %>
 ExecReload=/bin/kill -TSTP $MAINPID
-ExecStop=/bin/kill -TERM $MAINPID
 StandardOutput=append:<%= fetch(:puma_access_log) %>
 StandardError=append:<%= fetch(:puma_error_log) %>
 


### PR DESCRIPTION
This is to fix the error which happens when the service is stopped in systemd.
With the removed line of `ExecStop`, systemd sends a SIGTERM signal to the process when systemd needs to stop it, and the process starts graceful shutdown once the signal is received, but systemd won't wait until the graceful shutdown is done and send another signal of `KillSignal`, whose default value is SIGTERM. Puma graceful shutdown involves removing socket file, but when it receives the 2nd SIGTERM, the socket file has already been deleted, which causes the issue.
To fix that, we could just remove `ExecStop` from systemd file, and let systemd take care of it.
```
/.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/binder.rb:421:in `unlink': No such file or directory @ apply2files - /.../sockets/puma.sock (Errno::ENOENT)
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/binder.rb:421:in `block in close_listeners'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/binder.rb:416:in `each'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/binder.rb:416:in `close_listeners'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/launcher.rb:220:in `close_binder_listeners'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/cluster.rb:316:in `block in setup_signals'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/cluster.rb:457:in `rescue in run'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/cluster.rb:408:in `run'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/launcher.rb:182:in `run'
        from /.../ruby/2.5.0/gems/puma-5.1.1/lib/puma/cli.rb:80:in `run'
        from /.../ruby/2.5.0/gems/puma-5.1.1/bin/puma-wild:25:in `<main>'
```

systemd man-page: https://man7.org/linux/man-pages/man5/systemd.service.5.html
