### PR TITLE
fix: puma_systemctl_user default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_tag, fetch(:application)
     set :puma_restart_command, 'bundle exec puma'
     set :puma_service_unit_name, "puma_#{fetch(:application)}_#{fetch(:stage)}"
-    set :puma_systemctl_user, :system # defaults to system. If set to any other value, the --user arg is included #307
+    set :puma_systemctl_user, :system # accepts :user
+    set :puma_enable_lingering, fetch(:puma_systemctl_user) != :system # https://wiki.archlinux.org/index.php/systemd/User#Automatic_start-up_of_systemd_user_instances
+    set :puma_lingering_user, fetch(:user)
     set :puma_service_unit_env_file, nil
     set :puma_service_unit_env_vars, []
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_tag, fetch(:application)
     set :puma_restart_command, 'bundle exec puma'
     set :puma_service_unit_name, "puma_#{fetch(:application)}_#{fetch(:stage)}"
+    set :puma_systemctl_user, :system # defaults to system. If set to any other value, the --user arg is included #307
     set :puma_service_unit_env_file, nil
     set :puma_service_unit_env_vars, []
 

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -13,7 +13,7 @@ module Capistrano
     def set_defaults
       set_if_empty :puma_systemctl_bin, '/bin/systemctl'
       set_if_empty :puma_service_unit_name, -> { "puma_#{fetch(:application)}_#{fetch(:stage)}" }
-      set_if_empty :puma_service_unit_user, :system
+      set_if_empty :puma_systemctl_user, :system
       set_if_empty :puma_enable_lingering, false
     end
   end

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -14,7 +14,8 @@ module Capistrano
       set_if_empty :puma_systemctl_bin, '/bin/systemctl'
       set_if_empty :puma_service_unit_name, -> { "puma_#{fetch(:application)}_#{fetch(:stage)}" }
       set_if_empty :puma_systemctl_user, :system
-      set_if_empty :puma_enable_lingering, false
+      set_if_empty :puma_enable_lingering, -> { fetch(:puma_systemctl_user) != :system }
+      set_if_empty :puma_lingering_user, -> { fetch(:user) }
     end
   end
 end


### PR DESCRIPTION
Default to `puma_systemctl_user` to `:system` to avoid a breaking change introduced as part of #307.

