### PR TITLE
Implement puma systemd sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ install_plugin Capistrano::Puma::Daemon  # If you using puma daemonized (not sup
 ```
 or
 ```ruby
-install_plugin Capistrano::Puma::Systemd  # if you use SystemD 
+install_plugin Capistrano::Puma::Systemd  # if you use SystemD
 ```
 
 To prevent loading the hooks of the plugin, add false to the load_hooks param.
@@ -47,8 +47,8 @@ To prevent loading the hooks of the plugin, add false to the load_hooks param.
 To make it work with rvm, rbenv and chruby, install the plugin after corresponding library inclusion.
 ```ruby
     # Capfile
-    
-    require 'capistrano/rbenv'   
+
+    require 'capistrano/rbenv'
     require 'capistrano/puma'
     install_plugin Capistrano::Puma
 ```
@@ -127,6 +127,22 @@ To use customize environment variables
       PUMA_METRICS_HTTP=tcp://0.0.0.0:9393
   ]
 ```
+
+### Systemd Socket Activation
+
+Systemd socket activation starts your app upon first request if it is not already running
+
+```ruby
+    set :puma_enable_socket_service, true
+```
+
+For more information on socket activation have a look at the `systemd.socket` [man page](https://man7.org/linux/man-pages/man5/systemd.socket.5.html).
+
+To restart the listening socket using Systemd run
+```
+cap puma:systemd:restart_socket
+```
+This would also restart the puma instance as the puma service depends on the socket service being active
 
 ### Multi bind
 

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -13,6 +13,7 @@ module Capistrano
     def set_defaults
       set_if_empty :puma_systemctl_bin, '/bin/systemctl'
       set_if_empty :puma_service_unit_name, -> { "puma_#{fetch(:application)}_#{fetch(:stage)}" }
+      set_if_empty :puma_enable_socket_service, -> { false }
       set_if_empty :puma_systemctl_user, :system
       set_if_empty :puma_enable_lingering, -> { fetch(:puma_systemctl_user) != :system }
       set_if_empty :puma_lingering_user, -> { fetch(:user) }

--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -11,4 +11,12 @@ namespace :puma do
       end
     end
   end
+
+  desc 'Generate nginx configuration locally'
+  task :generate_nginx_config_locally do
+    fake_role = Struct.new(:hostname)
+    run_locally do
+      File.write('nginx.conf', git_plugin.compiled_template_puma("nginx_conf", fake_role.new("example.com")).string)
+    end
+  end
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -7,6 +7,7 @@ namespace :puma do
     desc 'Config Puma systemd service'
     task :config do
       on roles(fetch(:puma_role)) do |role|
+
         upload_compiled_template = lambda do |template_name, unit_filename|
           git_plugin.template_puma template_name, "#{fetch(:tmp_dir)}/#{unit_filename}", role
           systemd_path = fetch(:puma_systemd_conf_dir, git_plugin.fetch_systemd_unit_path)
@@ -18,24 +19,14 @@ namespace :puma do
           end
         end
 
-        upload_compiled_template.call(
-          "puma.service",
-          "#{fetch(:puma_service_unit_name)}.service"
-        )
+        upload_compiled_template.call("puma.service", "#{fetch(:puma_service_unit_name)}.service")
 
-        if fetch(:puma_enable_socket_service) do
-          upload_compiled_template.call(
-            "puma.socket",
-            "#{fetch(:puma_service_unit_name)}.socket"
-          )
+        if fetch(:puma_enable_socket_service)
+          upload_compiled_template.call("puma.socket", "#{fetch(:puma_service_unit_name)}.socket")
         end
 
-        # Restart systemd
-        if fetch(:puma_systemctl_user) == :system
-          sudo "#{fetch(:puma_systemctl_bin)} daemon-reload"
-        else
-          execute fetch(:puma_systemctl_bin), "--user", "daemon-reload"
-        end
+        # Reload systemd
+        git_plugin.execute_systemd("daemon-reload")
       end
     end
 
@@ -53,11 +44,11 @@ namespace :puma do
     desc 'Enable Puma systemd service'
     task :enable do
       on roles(fetch(:puma_role)) do
-        if fetch(:puma_systemctl_user) == :system
-          sudo "#{fetch(:puma_systemctl_bin)} enable #{fetch(:puma_service_unit_name)}"
-        else
-          execute "#{fetch(:puma_systemctl_bin)}", "--user", "enable", fetch(:puma_service_unit_name)
-          execute :loginctl, "enable-linger", fetch(:puma_lingering_user) if fetch(:puma_enable_lingering)
+        git_plugin.execute_systemd("enable", fetch(:puma_service_unit_name))
+        git_plugin.execute_systemd("enable", fetch(:puma_service_unit_name) + ".socket") if fetch(:puma_enable_socket_service)
+
+        if fetch(:puma_systemctl_user) != :system && fetch(:puma_enable_lingering)
+          execute :loginctl, "enable-linger", fetch(:puma_lingering_user)
         end
       end
     end
@@ -65,67 +56,52 @@ namespace :puma do
     desc 'Disable Puma systemd service'
     task :disable do
       on roles(fetch(:puma_role)) do
-        if fetch(:puma_systemctl_user) == :system
-          sudo "#{fetch(:puma_systemctl_bin)} disable #{fetch(:puma_service_unit_name)}"
-        else
-          execute "#{fetch(:puma_systemctl_bin)}", "--user", "disable", fetch(:puma_service_unit_name)
-        end
+        git_plugin.execute_systemd("disable", fetch(:puma_service_unit_name))
+        git_plugin.execute_systemd("disable", fetch(:puma_service_unit_name) + ".socket") if fetch(:puma_enable_socket_service)
       end
     end
 
+    desc 'Stop Puma socket via systemd'
+    task :stop_socket do
+      on roles(fetch(:puma_role)) do
+        git_plugin.execute_systemd("stop", fetch(:puma_service_unit_name) + ".socket")
+      end
+    end
+
+    desc 'Restart Puma socket via systemd'
+    task :restart_socket do
+      on roles(fetch(:puma_role)) do
+        git_plugin.execute_systemd("restart", fetch(:puma_service_unit_name) + ".socket")
+      end
+    end
   end
 
   desc 'Start Puma service via systemd'
   task :start do
     on roles(fetch(:puma_role)) do
-      if fetch(:puma_systemctl_user) == :system
-        sudo "#{fetch(:puma_systemctl_bin)} start #{fetch(:puma_service_unit_name)}"
-      else
-        execute "#{fetch(:puma_systemctl_bin)}", "--user", "start", fetch(:puma_service_unit_name)
-      end
+      git_plugin.execute_systemd("start", fetch(:puma_service_unit_name))
     end
   end
 
   desc 'Stop Puma service via systemd'
   task :stop do
     on roles(fetch(:puma_role)) do
-      if fetch(:puma_systemctl_user) == :system
-        sudo "#{fetch(:puma_systemctl_bin)} stop #{fetch(:puma_service_unit_name)}"
-      else
-        execute "#{fetch(:puma_systemctl_bin)}", "--user", "stop", fetch(:puma_service_unit_name)
-      end
+      git_plugin.execute_systemd("stop", fetch(:puma_service_unit_name))
     end
   end
 
   desc 'Restart Puma service via systemd'
   task :restart do
     on roles(fetch(:puma_role)) do
-      if fetch(:puma_systemctl_user) == :system
-        sudo "#{fetch(:puma_systemctl_bin)} restart #{fetch(:puma_service_unit_name)}"
-      else
-        execute "#{fetch(:puma_systemctl_bin)}", "--user", "restart", fetch(:puma_service_unit_name)
-      end
+      git_plugin.execute_systemd("restart", fetch(:puma_service_unit_name))
     end
   end
 
   desc 'Get Puma service status via systemd'
   task :status do
     on roles(fetch(:puma_role)) do
-      if fetch(:puma_systemctl_user) == :system
-        sudo "#{fetch(:puma_systemctl_bin)} status #{fetch(:puma_service_unit_name)}"
-      else
-        execute "#{fetch(:puma_systemctl_bin)}", "--user", "status", fetch(:puma_service_unit_name)
-      end
+      git_plugin.execute_systemd("status", fetch(:puma_service_unit_name))
+      git_plugin.execute_systemd("status", fetch(:puma_service_unit_name) + ".socket") if fetch(:puma_enable_socket_service)
     end
   end
-
-  def fetch_systemd_unit_path
-    if fetch(:puma_systemctl_user) == :system
-      "/etc/systemd/system/"
-    else
-      home_dir = backend.capture :pwd
-      File.join(home_dir, ".config", "systemd", "user")
-    end
-  end
-
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -21,6 +21,17 @@ namespace :puma do
       end
     end
 
+    desc 'Generate service configuration locally'
+    task :generate_config_locally do
+      fake_role = Struct.new(:hostname)
+      run_locally do
+        File.write('puma.service', git_plugin.compiled_template_puma("puma.service", fake_role.new("example.com")).string)
+        if fetch(:puma_enable_socket_service)
+          File.write('puma.socket', git_plugin.compiled_template_puma("puma.socket", fake_role.new("example.com")).string)
+        end
+      end
+    end
+
     desc 'Enable Puma systemd service'
     task :enable do
       on roles(fetch(:puma_role)) do

--- a/lib/capistrano/templates/nginx_conf.erb
+++ b/lib/capistrano/templates/nginx_conf.erb
@@ -1,12 +1,11 @@
 upstream puma_<%= fetch(:nginx_config_name) %> { <%
-  @backends = [fetch(:puma_bind)].flatten.map do |m|
-  etype, address  = /(tcp|unix|ssl):\/{1,2}(.+)/.match(m).captures
-  if etype == 'unix'
-    "server #{etype}:#{address} #{fetch(:nginx_socket_flags)};"
-  else
-    "server #{address.gsub(/0\.0\.0\.0(.+)/, "127.0.0.1\\1")} #{fetch(:nginx_http_flags)};"
+  @backends = puma_binds.map do |bind|
+     if bind.unix?
+       "server unix:#{bind.address} #{fetch(:nginx_socket_flags)};"
+     else
+       "server #{bind.local.address} #{fetch(:nginx_http_flags)};"
+     end
   end
-end
 %><% @backends.each do |server| %>
   <%= server %><% end %>
 }

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -7,6 +7,8 @@ After=network.target
 Type=simple
 <%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
+# Support older bundler versions where file descriptors weren't kept
+# See https://github.com/rubygems/rubygems/issues/3254
 ExecStart=<%= expanded_bundle_command %> exec --keep-file-descriptors puma -C <%= fetch(:puma_conf) %>
 ExecReload=/bin/kill -TSTP $MAINPID
 StandardOutput=append:<%= fetch(:puma_access_log) %>

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -1,12 +1,13 @@
 [Unit]
 Description=Puma HTTP Server for <%= "#{fetch(:application)} (#{fetch(:stage)})" %>
 After=network.target
+<%= "Requires=#{fetch(:puma_service_unit_name)}.socket" if fetch(:puma_enable_socket_service) %>
 
 [Service]
 Type=simple
 <%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
-ExecStart=<%= SSHKit.config.command_map[:bundle] %> exec puma -C <%= fetch(:puma_conf) %>
+ExecStart=<%= SSHKit.config.command_map[:bundle %> exec --keep-file-descriptors puma -C <%= fetch(:puma_conf) %>
 ExecReload=/bin/kill -TSTP $MAINPID
 StandardOutput=append:<%= fetch(:puma_access_log) %>
 StandardError=append:<%= fetch(:puma_error_log) %>

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 <%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
-ExecStart=<%= SSHKit.config.command_map[:bundle %> exec --keep-file-descriptors puma -C <%= fetch(:puma_conf) %>
+ExecStart=<%= expanded_bundle_command %> exec --keep-file-descriptors puma -C <%= fetch(:puma_conf) %>
 ExecReload=/bin/kill -TSTP $MAINPID
 StandardOutput=append:<%= fetch(:puma_access_log) %>
 StandardError=append:<%= fetch(:puma_error_log) %>

--- a/lib/capistrano/templates/puma.socket.erb
+++ b/lib/capistrano/templates/puma.socket.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=Puma HTTP Server Accept Sockets for <%= "#{fetch(:application)} (#{fetch(:stage)})" %>
+
+[Socket]
+<% puma_binds.each do |bind| -%>
+<%= "ListenStream=#{bind.local.address}" %>
+<% end -%>
+
+NoDelay=true
+ReusePort=true
+Backlog=1024
+
+SyslogIdentifier=puma_socket
+
+[Install]
+WantedBy=sockets.target

--- a/lib/capistrano/templates/puma.socket.erb
+++ b/lib/capistrano/templates/puma.socket.erb
@@ -6,7 +6,7 @@ Description=Puma HTTP Server Accept Sockets for <%= "#{fetch(:application)} (#{f
 <%= "ListenStream=#{bind.local.address}" %>
 <% end -%>
 
-NoDelay=true
+<%= "NoDelay=true" if fetch(:puma_systemctl_user) == :system %>
 ReusePort=true
 Backlog=1024
 

--- a/lib/capistrano/templates/puma.socket.erb
+++ b/lib/capistrano/templates/puma.socket.erb
@@ -6,6 +6,12 @@ Description=Puma HTTP Server Accept Sockets for <%= "#{fetch(:application)} (#{f
 <%= "ListenStream=#{bind.local.address}" %>
 <% end -%>
 
+# Don't let systemd accept the request, wait for Puma to do that.
+# Systemd will start the puma service upon first request if it wasn't started.
+#
+# You might also want to set your Nginx upstream to have a fail_timeout large enough to accomodate your app's
+# startup time.
+Accept=no
 <%= "NoDelay=true" if fetch(:puma_systemctl_user) == :system %>
 ReusePort=true
 Backlog=1024


### PR DESCRIPTION
This PR adds support for using systemd socket activation with Puma. 

I have not yet tested the implementation when using the system user, but this may require that `SocketUser` and `SocketGroup` be specified in the socket file. 

It would be great if you could test it if you have the time @seuros.

When merged this closes #320 

**Tasks**
- [x] Update README's _Other Configs_ section
- [x] Document the extra capistrano functions  (and the fact that they might stop puma!) `cap puma:systemd:restart_socket`
- [x] Set PR to Ready

**PS** I still need to finish some local testing before I can merge, but so far the whole deployment process has run without a hitch!