### PR TITLE
Add option for phased restart of puma

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ To use customize environment variables
   ]
 ```
 
+To use [phased restart](https://github.com/puma/puma/blob/master/docs/restart.md) for zero downtime deployments:
+
+```ruby
+  set :puma_phased_restart, true
+```
+
 ### Systemd Socket Activation
 
 Systemd socket activation starts your app upon first request if it is not already running
@@ -192,6 +198,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_lingering_user, fetch(:user)
     set :puma_service_unit_env_file, nil
     set :puma_service_unit_env_vars, []
+    set :puma_phased_restart, false
 
     set :nginx_config_name, "#{fetch(:application)}_#{fetch(:stage)}"
     set :nginx_flags, 'fail_timeout=0'

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -3,7 +3,7 @@ module Capistrano
     include PumaCommon
 
     def register_hooks
-      after 'deploy:finished', 'puma:reload'
+      after 'deploy:finished', 'puma:smart_restart'
     end
 
     def define_tasks
@@ -17,6 +17,7 @@ module Capistrano
       set_if_empty :puma_systemctl_user, :system
       set_if_empty :puma_enable_lingering, -> { fetch(:puma_systemctl_user) != :system }
       set_if_empty :puma_lingering_user, -> { fetch(:user) }
+      set_if_empty :puma_phased_restart, -> { false }
     end
 
     def expanded_bundle_command

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -90,6 +90,15 @@ namespace :puma do
     end
   end
 
+  desc 'Restarts or reloads Puma service via systemd'
+  task :smart_restart do
+    if fetch(:puma_phased_restart)
+      invoke 'puma:reload'
+    else
+      invoke 'puma:restart'
+    end
+  end
+
   desc 'Restart Puma service via systemd'
   task :restart do
     on roles(fetch(:puma_role)) do


### PR DESCRIPTION
As discussed in #329.

Reverted `puma:restart` to be the default. To enable phased restart:

```ruby
set :puma_phased_restart, true
```

I called it `smart_restart` internally as there is the same pattern already for the daemonize plugin.