### PR TITLE
fix to error while invoking puma:systemd:generate_config_locally

### DIFF
--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -32,11 +32,11 @@ namespace :puma do
 
     desc 'Generate service configuration locally'
     task :generate_config_locally do
-      fake_role = Struct.new(:hostname)
+      fake_role = Struct.new(:hostname, :user, :properties)
       run_locally do
-        File.write('puma.service', git_plugin.compiled_template_puma("puma.service", fake_role.new("example.com")).string)
+        File.write('puma.service', git_plugin.compiled_template_puma("puma.service", fake_role.new("example.com", "puma_user")).string)
         if fetch(:puma_enable_socket_service)
-          File.write('puma.socket', git_plugin.compiled_template_puma("puma.socket", fake_role.new("example.com")).string)
+          File.write('puma.socket', git_plugin.compiled_template_puma("puma.socket", fake_role.new("example.com", "puma_user")).string)
         end
       end
     end


### PR DESCRIPTION
This PR fix the following error.

```
$ cap staging puma:systemd:generate_config_locally
(Backtrace restricted to imported tasks)
cap aborted!
NoMethodError: undefined method `properties' for #<struct hostname="example.com">

Tasks: TOP => puma:systemd:generate_config_locally
(See full trace by running task with --trace)
```                                           