### PR TITLE
Remove unneeded post-install message

### DIFF
--- a/capistrano3-puma.gemspec
+++ b/capistrano3-puma.gemspec
@@ -21,8 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano', '~> 3.7'
   spec.add_dependency 'capistrano-bundler'
   spec.add_dependency 'puma' , '>= 4.0', '< 6.0'
-  spec.post_install_message = %q{
-    All plugins need to be explicitly installed with install_plugin.
-    Please see README.md
-  }
 end


### PR DESCRIPTION
capistrano3-puma is the only Capistrano plugin that does it. Use of `install_plugin` is standard - no need to announce it.