### PR TITLE
Update `linked_dirs` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cap production puma:config
 By default the file located in  `shared/puma.rb`
 
 
-Ensure that `tmp/pids` and ` tmp/sockets log` are shared (via `linked_dirs`):
+Ensure that `tmp/pids`, `tmp/sockets` and `log` are shared (via `linked_dirs`):
 
 `This step is mandatory before deploying, otherwise puma server won't start`
 


### PR DESCRIPTION
Sorry for a README commit, but this step can be a bit confusing, because it lists `tmp/sockets log` as one 😆 