### PR TITLE
Fixed running systemctl status command when system user

### DIFF
--- a/lib/capistrano/puma/version.rb
+++ b/lib/capistrano/puma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Capistrano
-  PUMAVERSION = '5.2.0'
+  PUMAVERSION = '5.2.1'
 end

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -110,7 +110,7 @@ namespace :puma do
   task :reload do
     on roles(fetch(:puma_role)) do
       service_ok = if fetch(:puma_systemctl_user) == :system
-        execute("#{fetch(:puma_systemctl_bin)} status #{fetch(:puma_service_unit_name)} > /dev/null", raise_on_non_zero_exit: false)
+        sudo("#{fetch(:puma_systemctl_bin)} status #{fetch(:puma_service_unit_name)} > /dev/null", raise_on_non_zero_exit: false)
       else
         execute("#{fetch(:puma_systemctl_bin)} --user status #{fetch(:puma_service_unit_name)} > /dev/null", raise_on_non_zero_exit: false)
       end


### PR DESCRIPTION
Fixes issue https://github.com/seuros/capistrano-puma/issues/339

**Problem**
```
00:03 puma:reload
      01 /bin/systemctl status puma_production > /dev/null
      01 Failed to issue method call: No such interface 'org.freedesktop.DBus.Properties' on object at path /org/freedesktop/systemd1/unit/puma_production_service
      01
    ✘ 01 deploy@xx.xxx.xx.x 0.569s
      02 sudo /bin/systemctl reload puma_production
    ✔ 02 deploy@xx.xxx.xx.x 0.782s

```

**With fix applied**
```
00:02 puma:reload
      01 sudo /bin/systemctl status puma_production > /dev/null
    ✔ 01 deploy@xx.xxx.xx.x 0.536s
      02 sudo /bin/systemctl reload puma_production
    ✔ 02 deploy@xx.xxx.xx.x 0.613s
```