### PR TITLE
Allows passing a rackup file path to puma

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ For ActiveRecord the following line to your deploy.rb
     set :puma_init_active_record, true
 ```
 
+### Rackup file path
+
+In the case you're using a Rackup file to be used to start Puma, you can pass
+its path to the `:puma_rackup_file_path` parameter :
+
+```ruby
+set :puma_rackup_file_path, 'path/to/my/config.ru'
+```
+
 ### Other configs
 
 Configurable options, shown here with defaults: Please note the configuration options below are not required unless you are trying to override a default setting, for instance if you are deploying on a host on which you do not have sudo or root privileges and you need to restrict the path. These settings go in the deploy.rb file.

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -21,7 +21,7 @@ WatchdogSec=10
 WorkingDirectory=<%= current_path %>
 # Support older bundler versions where file descriptors weren't kept
 # See https://github.com/rubygems/rubygems/issues/3254
-ExecStart=<%= expanded_bundle_command %> exec --keep-file-descriptors puma
+ExecStart=<%= expanded_bundle_command %> exec --keep-file-descriptors puma <%= fetch(:puma_rackup_file_path, '') %>
 ExecReload=/bin/kill -USR1 $MAINPID
 
 <%="EnvironmentFile=#{fetch(:puma_service_unit_env_file)}" if fetch(:puma_service_unit_env_file) %>


### PR DESCRIPTION
We are using Puma in order to run the ActionCable as a separated process, and to do so we are using a Rackup file.

The way to get puma accepting Rackup file is to pass it as a command line argument. This PR adds the new `:puma_rackup_file_path` parameter doing precisely that.