### PR TITLE
Cleans up the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,6 @@ Multi-bind can be set with an array in the puma_bind variable
     * Listening on tcp://0.0.0.0:9292
     * Listening on unix:///tmp/puma.sock
 
-### Active Record
-
-For ActiveRecord the following line to your deploy.rb
-```ruby
-    set :puma_init_active_record, true
-```
-
 ### Other configs
 
 Configurable options, shown here with defaults: Please note the configuration options below are not required unless you are trying to override a default setting, for instance if you are deploying on a host on which you do not have sudo or root privileges and you need to restrict the path. These settings go in the deploy.rb file.


### PR DESCRIPTION
After having searched through this gem's history, in order to figure out what was doing that `:puma_init_active_record` parameter, I found that this parameter doesn't exist anymore, therefore this PR removes this README.md section.