### PR TITLE
Minor release to support puma v6.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+
+- Bump puma support to v6.x
 
 ## [5.2.0](https://github.com/seuros/capistrano-puma/tree/5.2.0) (2021-09-11)
 

--- a/capistrano3-puma.gemspec
+++ b/capistrano3-puma.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '~> 3.7'
   spec.add_dependency 'capistrano-bundler'
-  spec.add_dependency 'puma' , '>= 4.0', '< 6.0'
+  spec.add_dependency 'puma' , '>= 4.0', '< 7.0'
   spec.post_install_message = %q{
     All plugins need to be explicitly installed with install_plugin.
     Please see README.md


### PR DESCRIPTION
fixes #358

Note to maintainer: In case you accept this PR then you must create a release branch and merge this PR onto that.

For instance:

```
git checkout -b release/5.3.x v5.2.0

```


### Puma v6 breaking changes investigation

Here are a copy of [Puma 6.0 release notes](https://github.com/puma/puma/blob/master/History.md#600--2022-10-14) breaking changes:

> ## 6.0.0 / 2022-10-14
> 
> * Breaking Changes
>   * Dropping Ruby 2.2 and 2.3 support (now 2.4+)
>   * Remote_addr functionality has changed
>   * No longer supporting Java 1.7 or below (JRuby 9.1 was the last release to support this)
>   * Remove nakayoshi GC
>   * wait_for_less_busy_worker is now default on
>   * Prefix all environment variables with `PUMA_` [#2924](https://github.com/puma/puma/pull/2924)
>   * Removed some constants
>   * The following classes are now part of Puma's private API: `Client`, `Cluster::Worker`, `Cluster::Worker`, `HandleRequest`.
>   * Configuration constants like `DefaultRackup` removed
>   * Extracted `LogWriter` from `Events`
>   * Only accept the standard 8 HTTP methods, others rejected with 501.


## investigation of actual occurrences of the deprecated items
None found in the code of the plugin for the above mentioned strings:

patterns.txt:
```
Client
Cluster::Worker
Cluster::Worker
HandleRequest
DefaultRackup
LogWriter
DISABLE_SSL
MAKE_WARNINGS_INTO_ERRORS
WAIT_FOR_LESS_BUSY_WORKERS
DEBUG
````

```
git grep -f patterns.txt
```

So, I found none of the deprecated/changed strings
