### PR TITLE
Checking unit_type before watchdog config

### DIFF
--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -16,7 +16,9 @@ After=syslog.target network.target
 
 [Service]
 Type=<%= service_unit_type %>
+<% if service_unit_type == "notify" -%>
 WatchdogSec=10
+<% end -%>
 <%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
 ExecStart=<%= expanded_bundle_command %> exec puma -e <%= fetch(:puma_env) %>


### PR DESCRIPTION
Related to this issue #362 if service_unit_type is "simple", Puma service will be restarted every few seconds.

To prevent this issue we have to configure systemd watchdog only in "notify" types.