### PR TITLE
Fix deprecation warning using ERB.new in version 5.2.0

### DIFF
--- a/lib/capistrano/puma.rb
+++ b/lib/capistrano/puma.rb
@@ -44,7 +44,7 @@ module Capistrano
           File.expand_path("../templates/#{from}.rb.erb", __FILE__)
       ].detect { |path| File.file?(path) }
       erb = File.read(file)
-      StringIO.new(ERB.new(erb, nil, '-').result(binding))
+      StringIO.new(ERB.new(erb, trim_mode: '-').result(binding))
     end
 
     def template_puma(from, to, role)


### PR DESCRIPTION
I'm using version 5.2.0 and I'm getting the following warnings when running the `puma:systemd:config` task:

```
capistrano3-puma-5.2.0/lib/capistrano/puma.rb:47: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.

capistrano3-puma-5.2.0/lib/capistrano/puma.rb:47: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

This was fixed in the master branch in commit a7d33304c5. However, version 6.0.0 hasn't been released yet, so this is a fix for the latest "stable" branch.

Note: this is supposed to be a **backport to a 5.x branch**, but such branch doesn't exist right now.