### PR TITLE
Fix #384: Add documentation for puma.rb symlink requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Unreleased](https://github.com/seuros/capistrano-puma/compare/v5.2.0...master)
 - Restored default value for `puma_bind` to fix socket activation (Issue #387)
+- Added documentation for puma.rb symlink requirement in v6.0.0 (Issue #384)
 - Removed support for support for monit and upstart. (will add them back if someone is willing to maintain them)
 - Sync configuration with capistrano-sidekiq
 - Support for notify systemd service. Add sd_notify gem to your Gemfile.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ To make it work with rvm, rbenv and chruby, install the plugin after correspondi
 ### Config
 
 Puma configuration is expected to be in `config/puma.rb` or `config/puma/#{fetch(:puma_env)}.rb` and checked in your repository.
-Uploading the configuration via capistrano was removed as it was causing problems with custom configurations.
+
+Starting with version 6.0.0, you need to manage the puma configuration file yourself. Here are the steps:
+
+1. Create your puma configuration in `shared/config/puma.rb` on the server
+2. Add it to linked_files in your `deploy.rb`:
+   ```ruby
+   append :linked_files, 'config/puma.rb'
+   ```
+
+This ensures the puma configuration persists across deployments. The systemd service will start puma with `puma -e <environment>` from your app's current directory.
 
 ### Deployment
 


### PR DESCRIPTION
- Document the breaking change in v6.0.0 regarding puma configuration
- Add clear instructions for creating and symlinking puma.rb
- Explain that systemd now uses 'puma -e <env>' instead of 'puma -C <path>'
- Update CHANGELOG to document this fix