### PR TITLE
Fix #373: Make WatchdogSec configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 [Unreleased](https://github.com/seuros/capistrano-puma/compare/v5.2.0...master)
 - Restored default value for `puma_bind` to fix socket activation (Issue #387)
 - Added documentation for puma.rb symlink requirement in v6.0.0 (Issue #384)
+- Made WatchdogSec configurable via `puma_systemd_watchdog_sec` (Issue #373)
 - Removed support for support for monit and upstart. (will add them back if someone is willing to maintain them)
 - Sync configuration with capistrano-sidekiq
 - Support for notify systemd service. Add sd_notify gem to your Gemfile.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_user, fetch(:user)
     set :puma_role, :web
     set :puma_bind, "unix://#{shared_path}/tmp/sockets/puma.sock"
+    set :puma_systemd_watchdog_sec, 10  # Set to 0 or false to disable watchdog
     set :puma_service_unit_env_files, []
     set :puma_service_unit_env_vars, []
 ```

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -14,6 +14,7 @@ module Capistrano
       set_if_empty :puma_systemctl_bin, -> { fetch(:systemctl_bin, '/bin/systemctl') }
       set_if_empty :puma_service_unit_name, -> { "#{fetch(:application)}_puma_#{fetch(:stage)}" }
       set_if_empty :puma_enable_socket_service, false
+      set_if_empty :puma_systemd_watchdog_sec, 10
 
       set_if_empty :puma_service_unit_env_files, -> { fetch(:service_unit_env_files, []) }
       set_if_empty :puma_service_unit_env_vars, -> { fetch(:service_unit_env_vars, []) }

--- a/lib/capistrano/templates/puma.service.erb
+++ b/lib/capistrano/templates/puma.service.erb
@@ -16,7 +16,9 @@ After=syslog.target network.target
 
 [Service]
 Type=<%= service_unit_type %>
-WatchdogSec=10
+<% if fetch(:puma_systemd_watchdog_sec) && fetch(:puma_systemd_watchdog_sec) > 0 %>
+WatchdogSec=<%= fetch(:puma_systemd_watchdog_sec) %>
+<% end %>
 <%="User=#{puma_user(@role)}" if fetch(:puma_systemctl_user) == :system %>
 WorkingDirectory=<%= current_path %>
 ExecStart=<%= expanded_bundle_command %> exec puma -e <%= fetch(:puma_env) %>


### PR DESCRIPTION
- Added puma_systemd_watchdog_sec configuration option (default: 10)
- Updated systemd template to only include WatchdogSec if value > 0
- Setting to 0 or false disables the watchdog entirely
- Updated README and CHANGELOG to document the new option

This addresses issues with systemd bugs and slow application startup times where the hardcoded 10-second watchdog would kill the puma process.