### PR TITLE
let puma restart before deploy:cleanup happens

### DIFF
--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -3,7 +3,7 @@ module Capistrano
     include PumaCommon
 
     def register_hooks
-      after 'deploy:finished', 'puma:smart_restart'
+      after 'deploy:published', 'puma:smart_restart'
     end
 
     def define_tasks


### PR DESCRIPTION
At the moment, the hook restarts Puma after `deploy:finished`. This can cause problems if the number of failed deployments exceeds the value of `:keep_releases`.

The default [capistrano flow](https://capistranorb.com/documentation/getting-started/flow/) ends like this:

```
[...]
  deploy:updated
    [before]
      deploy:bundle
    [after]
      deploy:migrate
      deploy:compile_assets
      deploy:normalize_assets
  deploy:publishing
    deploy:symlink:release
  deploy:published
  deploy:finishing
    deploy:cleanup
  deploy:finished
    deploy:log_revision
```

For example, assume `:keep_releases` is set to `5`. If your deployment fails five times at deploy:migrate, you will end up with at least six release directories. The oldest one being the currently active release.

Now, if the next deployment succeeds past `deploy:migrate`, Capistrano’s `deploy:cleanup` will remove the previously active release directory. Unfortunately, this directory is still in use by Puma, so cleanup deletes the files Puma is currently serving before Puma has a chance to restart.

Even worse, there’s a chance `deploy:cleanup` itself fails because Puma still has open file handles in that directory. In that case, Puma won’t restart at all, leaving your application in a broken state.