### PR TITLE
fix!: detect Puma 6.1+ built-in sd_notify support

### DIFF
--- a/capistrano3-puma.gemspec
+++ b/capistrano3-puma.gemspec
@@ -10,15 +10,12 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/seuros/capistrano-puma'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4")
 
   spec.files = Dir.glob('lib/**/*') + %w(README.md CHANGELOG.md LICENSE.txt)
   spec.require_paths = ['lib']
 
   spec.add_dependency 'capistrano', '~> 3.7'
   spec.add_dependency 'capistrano-bundler'
-  spec.add_dependency 'puma', '>= 5.1', '< 8.0'
-  spec.post_install_message = %q{
-    Version 6.0.0 is a major release. Please see README.md, breaking changes are listed in CHANGELOG.md
-  }
+  spec.add_dependency 'puma', '>= 6.1', '< 8.0'
 end

--- a/lib/capistrano/puma.rb
+++ b/lib/capistrano/puma.rb
@@ -15,7 +15,7 @@ module Capistrano
     def puma_user(role)
       properties = role.properties
       return role.user unless properties
-      
+
       properties.fetch(:puma_user) || # local property for puma only
           fetch(:puma_user, nil) ||
           properties.fetch(:run_as) || # global property across multiple capistrano gems
@@ -31,10 +31,8 @@ module Capistrano
     def service_unit_type
       ## Jruby don't support notify
       return "simple" if RUBY_ENGINE == "jruby"
-      fetch(:puma_service_unit_type,
-      ## Check if sd_notify is available in the bundle
-        Gem::Specification.find_all_by_name("sd_notify").any? ? "notify" : "simple")
-
+      ## Puma 6.1+ has built-in sd_notify support
+      fetch(:puma_service_unit_type, "notify")
     end
 
     def compiled_template_puma(from, role)


### PR DESCRIPTION
- Update service_unit_type to default to 'notify' since Puma 6.1+ has built-in systemd support
- Require minimum Puma 6.1.0 in gemspec
- Set Ruby requirement to >= 2.4 to match Puma 6.1 minimum
- Remove obsolete sd_notify gem detection
- Remove outdated post-install message
- Users can still override with :puma_service_unit_type setting

Fixes #399
Fixes #398