### PR TITLE
Puma 8 support

### DIFF
--- a/capistrano3-puma.gemspec
+++ b/capistrano3-puma.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '~> 3.7'
   spec.add_dependency 'capistrano-bundler'
-  spec.add_dependency 'puma', '>= 6.1', '< 8.0'
+  spec.add_dependency 'puma', '>= 6.1', '< 9.0'
 end

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 
 gem "sinatra", "~> 4.1"
-gem "puma", "~> 7.0"
+gem "puma", "~> 8.0"

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -5,8 +5,8 @@ GEM
     logger (1.7.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.4)
-    puma (7.0.4)
+    nio4r (2.7.5)
+    puma (8.0.0)
       nio4r (~> 2.0)
     rack (3.2.3)
     rack-protection (4.2.0)
@@ -31,7 +31,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  puma (~> 7.0)
+  puma (~> 8.0)
   sinatra (~> 4.1)
 
 BUNDLED WITH

--- a/test/config/deploy.rb
+++ b/test/config/deploy.rb
@@ -1,4 +1,4 @@
-lock "~> 3.19.1"
+lock "~> 3.19"
 
 set :application, "capistrano-puma"
 set :repo_url, "https://github.com/seuros/capistrano-puma.git"


### PR DESCRIPTION
This PR adds Puma 8 compatibility by expanding the gem dependency range to allow Puma 8 and updating the test app to run against Puma 8.

It also relaxes the Capistrano lock in the deploy test fixture. Without that change, the test suite can fail before the Puma-related behavior is exercised when Bundler resolves a newer Capistrano 3.x version.

Tested locally with:
- bundle exec rake