### PR TITLE
Add puma_systemctl_reload_options for passing flags to systemctl reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,18 @@ Configurable options, shown here with defaults: Please note the configuration op
     set :puma_service_unit_env_files, []
     set :puma_service_unit_env_vars, []
     set :puma_service_unit_props, [] # Set extral puma service properties, such as ["MemoryMax=2G","TimeoutAbortSec=30"]
+    set :puma_systemctl_reload_options, [] # Extra flags passed to `systemctl reload`, e.g. ["--no-block"]
 ```
+
+`puma_systemctl_reload_options` is an array of extra flags appended to the `systemctl reload`
+command (empty by default). The flags are applied to `reload` only; the `restart` fallback,
+used when the service is not running, is left untouched.
+
+For example, with the default `Type=notify` service, `systemctl reload` waits for the phased
+restart to finish and every worker to re-signal readiness before it returns. Passing
+`%w[--no-block]` makes systemd enqueue the reload and return immediately instead. This is a
+trade-off — the deploy no longer waits on the reload, so it will not surface a failed restart;
+use it only when your rollout is verified by other means.
 
 __Notes:__ If you are setting values for variables that might be used by other plugins, use `append` instead of `set`. For example:
 ```ruby

--- a/lib/capistrano/puma/systemd.rb
+++ b/lib/capistrano/puma/systemd.rb
@@ -15,6 +15,7 @@ module Capistrano
       set_if_empty :puma_service_unit_name, -> { "#{fetch(:application)}_puma_#{fetch(:stage)}" }
       set_if_empty :puma_enable_socket_service, false
       set_if_empty :puma_systemd_watchdog_sec, 10
+      set_if_empty :puma_systemctl_reload_options, -> { fetch(:systemctl_reload_options, []) }
 
       set_if_empty :puma_service_unit_env_files, -> { fetch(:service_unit_env_files, []) }
       set_if_empty :puma_service_unit_env_vars, -> { fetch(:service_unit_env_vars, []) }

--- a/lib/capistrano/tasks/systemd.rake
+++ b/lib/capistrano/tasks/systemd.rake
@@ -118,14 +118,12 @@ namespace :puma do
                      execute("#{fetch(:puma_systemctl_bin)} --user status #{fetch(:puma_service_unit_name)} > /dev/null", raise_on_non_zero_exit: false)
                    end
       cmd = 'reload'
+      opts = Array(fetch(:puma_systemctl_reload_options))
       unless service_ok
         cmd = 'restart'
+        opts = []
       end
-      if fetch(:puma_systemctl_user) == :system
-        sudo "#{fetch(:puma_systemctl_bin)} #{cmd} #{fetch(:puma_service_unit_name)}"
-      else
-        execute "#{fetch(:puma_systemctl_bin)}", "--user", cmd, fetch(:puma_service_unit_name)
-      end
+      git_plugin.execute_systemd(*opts, cmd, fetch(:puma_service_unit_name))
     end
   end
 


### PR DESCRIPTION
## What

Adds a `puma_systemctl_reload_options` setting — an array of flags passed to the
`systemctl reload` command in `puma:reload`. Defaults to `[]`, so there is no
behavior change unless it is set. The flags are applied to `reload` only — the
existing `restart` fallback (taken when the unit is not running) is left
untouched.

## Why

With the default `Type=notify` unit, `systemctl reload` blocks until the phased
restart finishes and every worker re-signals readiness. In my deployment the
worker count is high enough that this takes several minutes, and holding the
deploy open that long exposes it to interruptions (network instability, etc.)
that can abort the run. Passing `--no-block` lets systemd enqueue the reload and
return immediately, removing that window — a trade-off, since the deploy no
longer waits on, or surfaces a failure from, the reload.

I considered a dedicated boolean (`puma_systemctl_reload_no_block`), but went
with a generic options array so the gem stays unopinionated. Full disclosure,
though: `--no-block` is realistically the only flag anyone will ever put in
here 😅 — the array just spares the gem from having to admit that out loud. If
you'd rather take the boolean, I'm happy to switch.

## Notes

- Follows the existing `puma_systemctl_*` naming.
- The `reload` task now dispatches through the existing `execute_systemd` helper
  instead of hand-rolling the `sudo` vs `--user` branches, matching the other
  tasks in `systemd.rake`.
- README updated.